### PR TITLE
✨ [Feat] JWT 기반 Spring Security 인증 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+reviews:
+  review_status: true
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - develop
+
+language: ko

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,19 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     compileOnly 'org.projectlombok:lombok'
@@ -34,6 +47,8 @@ dependencies {
     testImplementation 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/common/annotation/ApiErrorCodeExample.java
+++ b/src/main/java/com/example/demo/common/annotation/ApiErrorCodeExample.java
@@ -1,0 +1,19 @@
+package com.example.demo.common.annotation;
+
+import com.example.demo.common.enums.PredefinedErrorStatus;
+import com.example.demo.common.exception.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.example.demo.common.enums.PredefinedErrorStatus.DEFAULT;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+    ErrorStatus[] value() default {ErrorStatus._INTERNAL_SERVER_ERROR};
+
+    PredefinedErrorStatus status() default DEFAULT;
+}

--- a/src/main/java/com/example/demo/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/common/config/SwaggerConfig.java
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
 import static com.example.demo.common.consts.StaticVariable.*;
 import static java.util.stream.Collectors.groupingBy;
 
-/** Swagger 사용 환경을 위한 설정 파일 */
 @Slf4j
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/example/demo/common/consts/StaticVariable.java
+++ b/src/main/java/com/example/demo/common/consts/StaticVariable.java
@@ -19,6 +19,6 @@ public class StaticVariable {
     //JWT
     public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1일
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
-
+    public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 }
 

--- a/src/main/java/com/example/demo/common/enums/PredefinedErrorStatus.java
+++ b/src/main/java/com/example/demo/common/enums/PredefinedErrorStatus.java
@@ -1,0 +1,25 @@
+package com.example.demo.common.enums;
+
+import com.example.demo.common.exception.ErrorStatus;
+
+import java.util.List;
+
+public enum PredefinedErrorStatus {
+    DEFAULT(List.of(ErrorStatus._INTERNAL_SERVER_ERROR)),
+    AUTH(List.of(
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND
+    ));
+
+    private final List<ErrorStatus> errorStatuses;
+
+    PredefinedErrorStatus(List<ErrorStatus> errorStatuses) {
+        this.errorStatuses = errorStatuses;
+    }
+
+    public List<ErrorStatus> getErrorStatuses() {
+        return errorStatuses;
+    }
+}

--- a/src/main/java/com/example/demo/common/exception/ErrorStatus.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorStatus.java
@@ -24,18 +24,37 @@ public enum ErrorStatus implements BaseErrorCode{
     // 일반적인 요청 오류
     _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
     _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
-    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
+    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다."),
 
-    // user (4050-4099)
-    // schedule (4100-4149)
-    // consultationRequest (4150-4199)
-    // expertNotification (4200-4249)
-    // userNotification (4250-4299)
-    // proposal (4300-4349)
     // 인증 관련 오류 (4350~4399)
-    // image (4400-4449)
-    // report (4450~4499)
-    // advice (4500~4549)
+    @ExplainError("카카오 로그인 시 이메일 동의를 하지 않아 이메일을 가져오지 못했습니다.")
+    AUTH_OAUTH2_EMAIL_NOT_FOUND_FROM_PROVIDER(BAD_REQUEST, 4350, "카카오 계정에서 이메일을 가져올 수 없습니다. 이메일 제공 동의가 필요합니다."),
+    @ExplainError("DB에 존재하지 않는 Refresh Token입니다. 재로그인이 필요합니다.")
+    AUTH_REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, 4351, "유효하지 않은 Refresh Token입니다. 다시 로그인해주세요."),
+    @ExplainError("만료된 Refresh Token입니다. 재로그인이 필요합니다.")
+    AUTH_REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, 4352, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."),
+    @ExplainError("유효하지 않거나 변조된 Refresh Token입니다. 재로그인이 필요합니다.")
+    AUTH_INVALID_REFRESH_TOKEN(UNAUTHORIZED, 4355, "Refresh Token이 유효하지 않습니다. 다시 로그인해주세요."),
+    @ExplainError("해당 Role로는 접근할 수 없는 URI입니다.")
+    AUTH_ROLE_CANNOT_EXECUTE_URI(FORBIDDEN, 4353, "접근 권한이 없습니다."),
+    @ExplainError("인증이 필요한 URI입니다. Access Token을 헤더에 담아 요청해주세요.")
+    AUTH_MUST_AUTHORIZED_URI(UNAUTHORIZED, 4354, "로그인이 필요한 서비스입니다."),
+    @ExplainError("위조되었거나 잘못된 형식의 Access Token입니다.")
+    AUTH_INVALID_TOKEN(UNAUTHORIZED, 4356, "유효하지 않은 토큰입니다."),
+    @ExplainError("만료된 Access Token입니다. 재발급이 필요합니다.")
+    AUTH_TOKEN_HAS_EXPIRED(UNAUTHORIZED, 4357, "만료된 토큰입니다. 재발급 후 사용해주세요."),
+    @ExplainError("지원하지 않는 JWT 형식입니다.")
+    AUTH_TOKEN_IS_UNSUPPORTED(UNAUTHORIZED, 4358, "지원하지 않는 토큰 형식입니다."),
+    @ExplainError("토큰 값이 비어있습니다.")
+    AUTH_IS_NULL(UNAUTHORIZED, 4359, "토큰이 존재하지 않습니다."),
+
+    // member (4050~4099)
+    @ExplainError("존재하지 않는 NameType 입니다.")
+    MEMBER_NAME_TYPE_IS_INVALID(BAD_REQUEST, 4050, "유효하지 않은 이름 타입입니다."),
+    @ExplainError("존재하지 않는 회원입니다.")
+    MEMBER_NOT_FOUND(BAD_REQUEST, 4051, "존재하지 않는 회원입니다.");
+
+
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -1,0 +1,37 @@
+package com.example.demo.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate redisTemplate;
+
+    //FOR Refresh token(whiteList)
+    // key-value 설정
+    public void setValue(String token, String username) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(token, username, Duration.ofDays(7));
+    }
+
+    // key 값으로 value 가져오기
+    public String getValue(String token) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(token);
+    }
+
+    public void deleteValue(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            // "Bearer " 접두사 제거
+            token = token.substring(7);
+        }
+        redisTemplate.delete(token);
+    }
+}

--- a/src/main/java/com/example/demo/common/util/CookieUtil.java
+++ b/src/main/java/com/example/demo/common/util/CookieUtil.java
@@ -1,0 +1,51 @@
+package com.example.demo.common.util;
+
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.security.jwt.dto.JwtToken;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE;
+
+// CookieUtil.java
+@Component
+public class CookieUtil {
+
+    /** AccessToken을 헤더에, RefreshToken을 HttpOnly Cookie에 세팅한다. */
+    public void setTokenResponse(HttpServletResponse response, JwtToken jwtToken) {
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
+        response.addCookie(createRefreshTokenCookie(jwtToken.getRefreshToken()));
+    }
+
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+        return cookie;
+    }
+
+    /** 만료된 빈 Cookie를 덮어써서 브라우저의 RefreshToken Cookie를 삭제한다. */
+    public void expireRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
+    public String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (REFRESH_TOKEN_COOKIE.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/demo/domain/auditing/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/demo/domain/auditing/entity/BaseTimeEntity.java
@@ -1,0 +1,31 @@
+package com.example.demo.domain.auditing.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/example/demo/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/demo/domain/member/dto/MemberRequest.java
@@ -1,0 +1,29 @@
+package com.example.demo.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+public class MemberRequest {
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberRegisterDto{
+        private String kakaoEmail;
+        private String profileImg;
+        private String nickname;
+        private String name;
+    }
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberModifyDto{
+        private String profileImg;
+        private String nickname;
+        private String name;
+    }
+}

--- a/src/main/java/com/example/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/example/demo/domain/member/entity/Member.java
@@ -1,0 +1,93 @@
+package com.example.demo.domain.member.entity;
+
+import com.example.demo.domain.auditing.entity.BaseTimeEntity;
+import com.example.demo.domain.member.dto.MemberRequest;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@EqualsAndHashCode(of = "id", callSuper = false)
+@Table(name = "member")
+public class Member extends BaseTimeEntity implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", updatable = false, unique = true, nullable = false)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String kakaoEmail;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    private String profileImg;
+
+    private String name;
+
+    private String nickname;
+
+
+    public static Member of(MemberRequest.MemberRegisterDto memberRequest) {
+        return Member.builder()
+                .profileImg(memberRequest.getProfileImg())
+                .name(memberRequest.getName())
+                .nickname(memberRequest.getNickname())
+                .kakaoEmail(memberRequest.getKakaoEmail())
+                .build();
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void modifyInfo(MemberRequest.MemberModifyDto memberRequest) {
+        this.name = memberRequest.getName();
+        this.nickname = memberRequest.getNickname();
+        this.profileImg = memberRequest.getProfileImg();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER")); // TODO: 임의의 ROLE_USER 값 부여하였으므로 ROLE이 필요할 경우 추후 enum 타입으로 수정 예정
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/example/demo/domain/member/entity/Member.java
@@ -62,7 +62,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_USER")); // TODO: 임의의 ROLE_USER 값 부여하였으므로 ROLE이 필요할 경우 추후 enum 타입으로 수정 예정
+        return List.of(new SimpleGrantedAuthority("ROLE_USER")); // TODO: social 작업 끝나면 바로 admin, User enum타입으로 변경
     }
 
     @Override

--- a/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
@@ -1,0 +1,19 @@
+package com.example.demo.domain.member.repository;
+
+import com.example.demo.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByKakaoEmail(String kakaoEmail);
+
+    Optional<Member> findByUsername(String username);
+
+    boolean existsByName(String name);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/example/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/demo/domain/member/service/MemberQueryService.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.member.service;
+
+import com.example.demo.common.annotation.UseCase;
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getByKakaoEmail(String kakaoEmail) {
+        return memberRepository.findByKakaoEmail(kakaoEmail)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Member getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/demo/domain/member/service/MemberQueryService.java
@@ -1,32 +1,11 @@
 package com.example.demo.domain.member.service;
 
-import com.example.demo.common.annotation.UseCase;
-import com.example.demo.common.exception.ErrorStatus;
-import com.example.demo.common.exception.GeneralException;
 import com.example.demo.domain.member.entity.Member;
-import com.example.demo.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
-@UseCase
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class MemberQueryService {
+public interface MemberQueryService {
+    Member getByKakaoEmail(String kakaoEmail);
 
-    private final MemberRepository memberRepository;
+    Member getMemberByUsername(String username);
 
-    public Member getByKakaoEmail(String kakaoEmail) {
-        return memberRepository.findByKakaoEmail(kakaoEmail)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-    }
-
-    public Member getMemberByUsername(String username) {
-        return memberRepository.findByUsername(username)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-    }
-
-    public Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-    }
+    Member getMemberById(Long memberId);
 }

--- a/src/main/java/com/example/demo/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/member/service/MemberQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.example.demo.domain.member.service;
+
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberQueryServiceImpl implements MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getByKakaoEmail(String kakaoEmail) {
+        return memberRepository.findByKakaoEmail(kakaoEmail)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Member getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.example.demo.security.config;
+
+import com.example.demo.security.exception.JwtAccessDeniedHandler;
+import com.example.demo.security.exception.JwtAuthenticationEntryPoint;
+import com.example.demo.security.filter.JwtAuthenticationFilter;
+import com.example.demo.security.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+        // TODO : OAuth2 로그인 flow는 state 파라미터를 세션에 임시 저장해야 하므로 IF_REQUIRED 사용.
+        // 로그인 완료 후 발급된 JWT로 인증하므로 실질적으로 세션 인증은 사용하지 않음.
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/tokens/login",
+                                "/api/tokens/reissue",
+                                "/api/tokens/logout",
+                                "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/v1/test/health-check"
+                        ).permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/demo/security/controller/TokenApiController.java
+++ b/src/main/java/com/example/demo/security/controller/TokenApiController.java
@@ -1,0 +1,103 @@
+package com.example.demo.security.controller;
+
+import com.example.demo.api.common.dto.ApiResponseDto;
+import com.example.demo.common.annotation.DisableSwaggerSecurity;
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.security.jwt.dto.AccessTokenResponse;
+import com.example.demo.security.jwt.dto.JwtToken;
+import com.example.demo.security.jwt.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Token API", description = "토큰 API")
+@ApiResponse(responseCode = "2000", description = "성공")
+@RequiredArgsConstructor
+@RequestMapping("/api/tokens")
+@RestController
+public class TokenApiController {
+
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+
+    private final TokenService tokenService;
+
+    @Operation(
+            summary = "로그인(토큰 생성)",
+            description = "카카오 이메일로 로그인합니다. AccessToken은 헤더(Authorization)와 바디로, RefreshToken은 HttpOnly Cookie로 전달됩니다."
+    )
+    @DisableSwaggerSecurity
+    @GetMapping("/login")
+    public ApiResponseDto<AccessTokenResponse>  login(@RequestParam String kakaoEmail,
+                                                     HttpServletResponse response) {
+        JwtToken jwtToken = tokenService.login(kakaoEmail);
+        setTokenResponse(response, jwtToken);
+        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
+    }
+
+    @Operation(
+            summary = "토큰 재발행",
+            description = "Cookie의 RefreshToken으로 새 AccessToken을 발급합니다. AccessToken은 헤더(Authorization)와 바디로, 새 RefreshToken은 Cookie로 전달됩니다."
+    )
+    @DisableSwaggerSecurity
+    @PostMapping("/reissue")
+    public ApiResponseDto<AccessTokenResponse> reissue(HttpServletRequest request,
+                                                       HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        JwtToken jwtToken = tokenService.issueTokens(refreshToken);
+        setTokenResponse(response, jwtToken);
+        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "Cookie의 RefreshToken을 삭제하고 Redis에서 제거합니다."
+    )
+    @PostMapping("/logout")
+    public ApiResponseDto<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        tokenService.logout(refreshToken);
+        expireRefreshTokenCookie(response);
+        return ApiResponseDto.onSuccess(null);
+    }
+
+    /** AccessToken을 헤더에, RefreshToken을 HttpOnly Cookie에 세팅한다. */
+    private void setTokenResponse(HttpServletResponse response, JwtToken jwtToken) {
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
+        response.addCookie(createRefreshTokenCookie(jwtToken.getRefreshToken()));
+    }
+
+    private Cookie createRefreshTokenCookie(String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+        return cookie;
+    }
+
+    /** 만료된 빈 Cookie를 덮어써서 브라우저의 RefreshToken Cookie를 삭제한다. */
+    private void expireRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (REFRESH_TOKEN_COOKIE.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/demo/security/controller/TokenApiController.java
+++ b/src/main/java/com/example/demo/security/controller/TokenApiController.java
@@ -4,6 +4,8 @@ import com.example.demo.api.common.dto.ApiResponseDto;
 import com.example.demo.common.annotation.DisableSwaggerSecurity;
 import com.example.demo.common.exception.ErrorStatus;
 import com.example.demo.common.exception.GeneralException;
+import com.example.demo.common.util.CookieUtil;
+import com.example.demo.security.filter.JwtAuthenticationFilter;
 import com.example.demo.security.jwt.dto.AccessTokenResponse;
 import com.example.demo.security.jwt.dto.JwtToken;
 import com.example.demo.security.jwt.service.TokenService;
@@ -17,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE;
+
 @Tag(name = "Token API", description = "토큰 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequiredArgsConstructor
@@ -24,8 +28,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class TokenApiController {
 
-    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
-
+    private final CookieUtil cookieUtil;
     private final TokenService tokenService;
 
     @Operation(
@@ -37,7 +40,7 @@ public class TokenApiController {
     public ApiResponseDto<AccessTokenResponse>  login(@RequestParam String kakaoEmail,
                                                      HttpServletResponse response) {
         JwtToken jwtToken = tokenService.login(kakaoEmail);
-        setTokenResponse(response, jwtToken);
+        cookieUtil.setTokenResponse(response, jwtToken);
         return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
     }
 
@@ -49,9 +52,9 @@ public class TokenApiController {
     @PostMapping("/reissue")
     public ApiResponseDto<AccessTokenResponse> reissue(HttpServletRequest request,
                                                        HttpServletResponse response) {
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(request);
         JwtToken jwtToken = tokenService.issueTokens(refreshToken);
-        setTokenResponse(response, jwtToken);
+        cookieUtil.setTokenResponse(response, jwtToken);
         return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
     }
 
@@ -61,43 +64,11 @@ public class TokenApiController {
     )
     @PostMapping("/logout")
     public ApiResponseDto<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(request);
         tokenService.logout(refreshToken);
-        expireRefreshTokenCookie(response);
+        cookieUtil.expireRefreshTokenCookie(response);
         return ApiResponseDto.onSuccess(null);
     }
 
-    /** AccessToken을 헤더에, RefreshToken을 HttpOnly Cookie에 세팅한다. */
-    private void setTokenResponse(HttpServletResponse response, JwtToken jwtToken) {
-        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
-        response.addCookie(createRefreshTokenCookie(jwtToken.getRefreshToken()));
-    }
 
-    private Cookie createRefreshTokenCookie(String refreshToken) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
-        return cookie;
-    }
-
-    /** 만료된 빈 Cookie를 덮어써서 브라우저의 RefreshToken Cookie를 삭제한다. */
-    private void expireRefreshTokenCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, null);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-    }
-
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (REFRESH_TOKEN_COOKIE.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_NOT_FOUND);
-    }
 }

--- a/src/main/java/com/example/demo/security/exception/CustomErrorSend.java
+++ b/src/main/java/com/example/demo/security/exception/CustomErrorSend.java
@@ -1,0 +1,19 @@
+package com.example.demo.security.exception;
+
+import com.example.demo.api.common.dto.ApiResponseDto;
+import com.example.demo.common.exception.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class CustomErrorSend {
+    public static void handleException(HttpServletResponse response, ErrorStatus errorStatus, String errorPoint) throws IOException {
+        ApiResponseDto<Object> apiResponseEntity = ApiResponseDto.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorPoint);
+
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponseEntity));
+    }
+}

--- a/src/main/java/com/example/demo/security/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/demo/security/exception/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.example.demo.security.exception;
+
+import com.example.demo.common.exception.ErrorStatus;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorStatus errorStatus = ErrorStatus.AUTH_ROLE_CANNOT_EXECUTE_URI;
+        CustomErrorSend.handleException(response, errorStatus, accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/com/example/demo/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/demo/security/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.example.demo.security.exception;
+
+import com.example.demo.common.exception.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorStatus errorStatus = ErrorStatus.AUTH_MUST_AUTHORIZED_URI;
+        CustomErrorSend.handleException(response, errorStatus, authException.getMessage());
+    }
+}

--- a/src/main/java/com/example/demo/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/example/demo/security/exception/JwtAuthenticationException.java
@@ -1,0 +1,10 @@
+package com.example.demo.security.exception;
+
+import com.example.demo.common.exception.ErrorStatus;
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(ErrorStatus errorStatus) {
+        super(errorStatus.name());
+    }
+}

--- a/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.example.demo.security.filter;
+
+import com.example.demo.security.jwt.service.TokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenService tokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // HttpServletRequest에서 JWT 토큰 추출
+        HttpServletRequest httpServletRequest = ((HttpServletRequest) request);
+
+        String requestURI = httpServletRequest.getRequestURI();
+        String token = null;
+        token = resolveToken(request);
+
+        if (token != null && tokenService.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+            Authentication authentication = tokenService.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            request.setAttribute("username", authentication.getName());
+            log.info("set Authentication to security context for '{}', uri: '{}', Role '{}'",
+                    authentication.getName(), ((HttpServletRequest) request).getRequestURI(), authentication.getAuthorities());
+        } else {
+            String uri = ((HttpServletRequest) request).getRequestURI();
+            if (!uri.equals("/health")) {
+                log.info("no valid JWT token found, uri: {}", uri);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
@@ -1,12 +1,18 @@
 package com.example.demo.security.filter;
 
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.common.util.CookieUtil;
+import com.example.demo.security.jwt.dto.JwtToken;
 import com.example.demo.security.jwt.service.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -15,12 +21,15 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenService tokenService;
+    private final CookieUtil cookieUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/example/demo/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/example/demo/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,32 @@
+package com.example.demo.security.filter;
+
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.security.exception.CustomErrorSend;
+import com.example.demo.security.exception.JwtAuthenticationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter  extends OncePerRequestFilter{
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtAuthenticationException authException) {
+            String errorCodeName = authException.getMessage();
+            ErrorStatus errorStatus = ErrorStatus.valueOf(errorCodeName);
+
+            CustomErrorSend.handleException(response, errorStatus, errorCodeName);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/dto/AccessTokenResponse.java
+++ b/src/main/java/com/example/demo/security/jwt/dto/AccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.example.demo.security.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/example/demo/security/jwt/dto/JwtToken.java
+++ b/src/main/java/com/example/demo/security/jwt/dto/JwtToken.java
@@ -1,0 +1,21 @@
+package com.example.demo.security.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class JwtToken {
+    private String grantType;   // JWT에 대한 인증 타입. Bearer 사용. 이후 HTTP 헤더에 prefix로 붙여줌
+    private String accessToken;
+    private String refreshToken;
+    private Date code_expire;
+    private Date refresh_expire;
+
+}

--- a/src/main/java/com/example/demo/security/jwt/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/demo/security/jwt/service/CustomUserDetailsService.java
@@ -1,0 +1,20 @@
+package com.example.demo.security.jwt.service;
+
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+@RequiredArgsConstructor
+@Service("customUserDetailsService")
+//TODO : 자체 로그인 구현 안 할 경우 제외 예정
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberQueryService memberQueryService;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member memberByUsername = memberQueryService.getMemberByUsername(username);
+        return memberByUsername;
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/service/TokenService.java
+++ b/src/main/java/com/example/demo/security/jwt/service/TokenService.java
@@ -1,0 +1,24 @@
+package com.example.demo.security.jwt.service;
+
+import com.example.demo.security.jwt.dto.JwtToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.Date;
+
+public interface TokenService {
+
+    JwtToken login(String kakaoEmail);
+    JwtToken issueTokens(String refreshToken);
+
+    JwtToken generateToken(Authentication authentication);
+
+    Authentication getAuthentication(String accessToken);
+
+    boolean validateToken(String token);
+
+    boolean logout(String refreshToken);
+
+    boolean existsRefreshToken(String refreshToken);
+
+    Date parseExpiration(String token);
+}

--- a/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
@@ -1,0 +1,199 @@
+package com.example.demo.security.jwt.service;
+
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.common.service.RedisService;
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.service.MemberQueryService;
+import com.example.demo.security.exception.JwtAuthenticationException;
+import com.example.demo.security.jwt.dto.JwtToken;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class TokenServiceImpl implements TokenService{
+    private final Key key;      //security yml 파일 생성 후 app.jwt.secret에 값 넣어주기(보안을 위해 따로 연락주세요)
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisService redisService;
+    private final MemberQueryService memberQueryService;
+
+    public TokenServiceImpl(@Value("${app.jwt.secret}") String key,
+                            AuthenticationManagerBuilder authenticationManagerBuilder,
+                            RedisService redisService,
+                            MemberQueryService memberQueryService) {
+        byte[] keyBytes = Decoders.BASE64.decode(key);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.redisService = redisService;
+        this.memberQueryService = memberQueryService;
+    }
+    @Override       //TODO oauth2적용시 필요 없음
+    public JwtToken login(String kakaoEmail) {
+        Member member = memberQueryService.getByKakaoEmail(kakaoEmail);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member, "",
+                member.getAuthorities());
+        return generateToken(authentication);
+    }
+
+    @Override
+    public JwtToken issueTokens(String refreshToken) {
+        // Refresh Token 유효성 검사
+        if (!validateToken(refreshToken) || !existsRefreshToken(refreshToken)) {
+            throw new GeneralException(ErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
+        }
+
+        // 이전 리프레시 토큰 삭제
+        redisService.deleteValue(refreshToken);
+
+        // 새로운 Authentication 객체 생성
+        Claims claims = parseClaims(refreshToken);
+        String username = claims.getSubject();
+        Member member = memberQueryService.getMemberByUsername(username);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member, "",
+                member.getAuthorities());
+
+        // 새 토큰 생성
+        JwtToken newTokens = generateToken(authentication);
+
+        return newTokens;
+    }
+
+    @Override
+    public JwtToken generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + 1800000);   // 30분
+        log.info("date = {}", accessTokenExpiresIn);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .setExpiration(new Date(now + 604800000))    // 7일
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // 새 리프레시 토큰을 Redis에 저장
+        redisService.setValue(refreshToken, authentication.getName());
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .code_expire(parseExpiration(accessToken))
+                .refresh_expire(parseExpiration(refreshToken))
+                .build();
+    }
+
+    @Override
+    public Authentication getAuthentication(String accessToken) {
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_INVALID_TOKEN);
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
+                .filter(auth -> !auth.isBlank())  // 빈 문자열 포함 금지
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_TOKEN_IS_UNSUPPORTED);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_IS_NULL);
+        }
+    }
+
+    @Override
+    public boolean logout(String refreshToken) {
+        redisService.deleteValue(refreshToken);
+        return true;
+    }
+
+    @Override
+    public boolean existsRefreshToken(String refreshToken) {
+        return redisService.getValue(refreshToken) != null;
+    }
+
+    @Override
+    public Date parseExpiration(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return claims.getExpiration();
+        } catch (JwtException exception) {
+            throw new JwtAuthenticationException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- Close #6 

## 🛠 작업 내용
- JWT 액세스/리프레시 토큰 발급 및 검증
- 리프레시 토큰 재발급 로직 추가
- 리프레시 토큰 무효화 방식 로그아웃 구현

## 테스트 순서
1. `GET /api/tokens/login`
- DB에 임의로 넣은 사용자의 카카오 이메일로 로그인합니다. 
- AccessToken은 헤더(Authorization)와 바디로, RefreshToken은 HttpOnly Cookie로 전달됩니다.
2. Swagger 우측 상단 [Authorize 🔓] 클릭 → 복사한 accessToken 입력
3. `POST /api/tokens/reissue` 토큰 재발급
- RefreshToken은 Cookie에서 자동으로 읽으므로 별도 입력 불필요
- 브라우저 개발자도구(F12) → Application → Cookies → refreshToken 이 변경됨을 확인할 수 있음.
4. `POST /api/tokens/logout` 로그아웃
- Cookie의 RefreshToken을 삭제하고 Redis에서 제거합니다.
- Cookies → refreshToken 이 삭제됨을 확인할 수 있음.
## 📸 결과 캡쳐화면

<img width="1452" height="489" alt="스크린샷 2026-04-06 오후 2 58 27" src="https://github.com/user-attachments/assets/2c7a5ef7-6af3-4a6b-91c7-c78642ad6708" />
<img width="1425" height="539" alt="스크린샷 2026-04-06 오후 2 58 38" src="https://github.com/user-attachments/assets/5d529ca6-6c4b-4570-92c9-cda63e50b7a8" />
<img width="791" height="508" alt="스크린샷 2026-04-06 오후 2 23 14" src="https://github.com/user-attachments/assets/bc65fc69-699a-4bd3-8561-68fb5a8d96b3" />
<img width="1445" height="803" alt="스크린샷 2026-04-06 오후 3 18 34" src="https://github.com/user-attachments/assets/605b178c-15a6-4c2d-ae7b-a4261105c605" />
<img width="952" height="344" alt="스크린샷 2026-04-06 오후 3 19 06" src="https://github.com/user-attachments/assets/1bd9aef6-9436-4d2d-9888-f0007d10d542" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카카오 OAuth2 연동 로그인, 액세스/리프레시 토큰 발급·재발급·로그아웃 API 추가
  * 브라우저용 HttpOnly 리프레시 쿠키 처리 및 Authorization 헤더 자동 설정
  * Redis 기반 리프레시 토큰 저장/검증으로 세션 관리 개선
  * 회원가입·프로필 조회/수정 기능 및 관련 조회 API 추가
  * 인증/인가 실패에 대한 상세한 오류 응답 및 상태 코드 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->