### PR TITLE
✨ [Feat] 카카오 OAuth2 로그인 구현 및 Swagger 테스트 환경 구성

### DIFF
--- a/src/main/java/com/example/demo/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/common/config/SwaggerConfig.java
@@ -3,7 +3,6 @@ package com.example.demo.common.config;
 import com.example.demo.common.annotation.*;
 import com.example.demo.common.annotation.ApiErrorExceptionsExample;
 import com.example.demo.common.annotation.ApiErrorStatusExample;
-import com.example.demo.common.annotation.DisableSwaggerSecurity;
 import com.example.demo.common.annotation.ExplainError;
 import com.example.demo.common.exception.BaseErrorCode;
 import com.example.demo.common.exception.GeneralException;
@@ -94,18 +93,12 @@ public class SwaggerConfig {
     @Bean
     public OperationCustomizer customize() {
         return (Operation operation, HandlerMethod handlerMethod) -> {
-            DisableSwaggerSecurity methodAnnotation =
-                    handlerMethod.getMethodAnnotation(DisableSwaggerSecurity.class);
             ApiErrorExceptionsExample apiErrorExceptionsExample =
                     handlerMethod.getMethodAnnotation(ApiErrorExceptionsExample.class);
             ApiErrorStatusExample apiErrorStatusExample =
                     handlerMethod.getMethodAnnotation(ApiErrorStatusExample.class);
 
             List<String> tags = getTags(handlerMethod);
-            // DisableSecurity 어노테이션있을시 스웨거 시큐리티 설정 삭제
-            if (methodAnnotation != null) {
-                operation.setSecurity(Collections.emptyList());
-            }
             // 태그 중복 설정시 제일 구체적인 값만 태그로 설정
             if (!tags.isEmpty()) {
                 operation.setTags(Collections.singletonList(tags.get(0)));

--- a/src/main/java/com/example/demo/common/consts/StaticVariable.java
+++ b/src/main/java/com/example/demo/common/consts/StaticVariable.java
@@ -16,6 +16,9 @@ public class StaticVariable {
     public static final String NOTIFICATION_READ = "isRead";
     public static final String PAGINATION_SORTING_BY_ID  = "id";
 
+    //OAuth2
+    public static final String KAKAO_OAUTH2_AUTHORIZATION_URI = "/oauth2/authorization/kakao";
+
     //JWT
     public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1일
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일

--- a/src/main/java/com/example/demo/common/resolver/DisableSwaggerSecurityResolver.java
+++ b/src/main/java/com/example/demo/common/resolver/DisableSwaggerSecurityResolver.java
@@ -1,0 +1,22 @@
+package com.example.demo.common.resolver;
+
+import com.example.demo.common.annotation.DisableSwaggerSecurity;
+import io.swagger.v3.oas.models.Operation;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Collections;
+
+@Component
+public class DisableSwaggerSecurityResolver implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        DisableSwaggerSecurity annotation = handlerMethod.getMethodAnnotation(DisableSwaggerSecurity.class);
+        if (annotation != null) {
+            operation.setSecurity(Collections.emptyList());
+        }
+        return operation;
+    }
+}

--- a/src/main/java/com/example/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/demo/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.example.demo.domain.member.controller;
+
+import com.example.demo.api.common.dto.ApiResponseDto;
+import com.example.demo.domain.member.dto.MemberResponse;
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.service.MemberQueryService;
+import com.example.demo.security.oauth.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Member API", description = "멤버 조회 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 멤버의 정보를 조회합니다. (JWT 필요)")
+    @GetMapping("/me")
+    public ApiResponseDto<MemberResponse.MemberInfoDto> getMe(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = memberQueryService.getMemberById(userDetails.getId());
+        return ApiResponseDto.onSuccess(MemberResponse.MemberInfoDto.from(member));
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/demo/domain/member/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
     private final MemberQueryService memberQueryService;
 
     @Operation(summary = "내 정보 조회", description = "로그인한 멤버의 정보를 조회합니다. (JWT 필요)")
-    @GetMapping("/me")
+    @GetMapping("/info")
     public ApiResponseDto<MemberResponse.MemberInfoDto> getMe(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = memberQueryService.getMemberById(userDetails.getId());

--- a/src/main/java/com/example/demo/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/demo/domain/member/dto/MemberResponse.java
@@ -1,0 +1,29 @@
+package com.example.demo.domain.member.dto;
+
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.entity.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberResponse {
+
+    @Getter
+    @Builder
+    public static class MemberInfoDto {
+        private Long id;
+        private String username;
+        private String kakaoEmail;
+        private String profileImg;
+        private Role role;
+
+        public static MemberInfoDto from(Member member) {
+            return MemberInfoDto.builder()
+                    .id(member.getId())
+                    .username(member.getUsername())
+                    .kakaoEmail(member.getKakaoEmail())
+                    .profileImg(member.getProfileImg())
+                    .role(member.getRole())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/example/demo/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -35,17 +36,19 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private String username;
 
     private String profileImg;
+    //TODO: 카카오에서 닉네임 받아서 그대로 사용하는건지 / 닉네임 입력칸을 따로 만드는 건지 확인
+    //private String name;
 
-    private String name;
+    //private String nickname;
 
-    private String nickname;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
 
     public static Member of(MemberRequest.MemberRegisterDto memberRequest) {
         return Member.builder()
                 .profileImg(memberRequest.getProfileImg())
-                .name(memberRequest.getName())
-                .nickname(memberRequest.getNickname())
+                .username(memberRequest.getName())
                 .kakaoEmail(memberRequest.getKakaoEmail())
                 .build();
     }
@@ -55,14 +58,13 @@ public class Member extends BaseTimeEntity implements UserDetails {
     }
 
     public void modifyInfo(MemberRequest.MemberModifyDto memberRequest) {
-        this.name = memberRequest.getName();
-        this.nickname = memberRequest.getNickname();
+        this.username = memberRequest.getName();
         this.profileImg = memberRequest.getProfileImg();
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_USER")); // TODO: social 작업 끝나면 바로 admin, User enum타입으로 변경
+        return Collections.singleton(new SimpleGrantedAuthority(this.role.getKey()));
     }
 
     @Override

--- a/src/main/java/com/example/demo/domain/member/entity/Role.java
+++ b/src/main/java/com/example/demo/domain/member/entity/Role.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER"), DORMANT("ROLE_DORMANT"), ADMIN("ROLE_ADMIN");
+
+    private final String key;
+}

--- a/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/demo/domain/member/repository/MemberRepository.java
@@ -11,9 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUsername(String username);
 
-    boolean existsByName(String name);
-
-    boolean existsByNickname(String nickname);
 
     boolean existsByUsername(String username);
 }

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.example.demo.security.oauth.handler.OAuth2LoginFailureHandler;
 import com.example.demo.security.oauth.handler.OAuth2LoginSuccessHandler;
 import com.example.demo.security.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,6 +17,11 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -30,9 +36,13 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -65,5 +75,19 @@ public class SecurityConfig {
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins.split(","))); // yml에서 읽은 프론트 주소만 허용
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
+        config.setExposedHeaders(List.of("Authorization"));  // 프론트에서 Authorization 헤더 읽을 수 있도록
+        config.setAllowCredentials(true);  // API 요청에 대해 CORS를 허용하도록 설정, Cookie(RefreshToken) 전송 허용 // 추후 프론트에서 요청을 할 때 withCredentials를 true로 header에 담아서 요청
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -4,6 +4,9 @@ import com.example.demo.security.exception.JwtAccessDeniedHandler;
 import com.example.demo.security.exception.JwtAuthenticationEntryPoint;
 import com.example.demo.security.filter.JwtAuthenticationFilter;
 import com.example.demo.security.filter.JwtExceptionFilter;
+import com.example.demo.security.oauth.handler.OAuth2LoginFailureHandler;
+import com.example.demo.security.oauth.handler.OAuth2LoginSuccessHandler;
+import com.example.demo.security.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +26,9 @@ public class SecurityConfig {
     private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -30,19 +36,28 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-        // TODO : OAuth2 로그인 flow는 state 파라미터를 세션에 임시 저장해야 하므로 IF_REQUIRED 사용.
-        // 로그인 완료 후 발급된 JWT로 인증하므로 실질적으로 세션 인증은 사용하지 않음.
+                // OAuth2 로그인 flow는 state 파라미터를 세션에 임시 저장해야 하므로 IF_REQUIRED 사용.
+                // 로그인 완료 후 발급된 JWT로 인증하므로 실질적으로 세션 인증은 사용하지 않음.
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/tokens/login",
                                 "/api/tokens/reissue",
                                 "/api/tokens/logout",
+                                "/api/auth/kakao",
+                                "/api/auth/kakao/callback",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/test/health-check"
                         ).permitAll()
                         .anyRequest().authenticated())
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler))
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))

--- a/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
+++ b/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
@@ -2,6 +2,7 @@ package com.example.demo.security.oauth.controller;
 
 import com.example.demo.api.common.dto.ApiResponseDto;
 import com.example.demo.common.annotation.DisableSwaggerSecurity;
+import com.example.demo.common.consts.StaticVariable;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,7 +41,7 @@ public class OAuthController {
     @DisableSwaggerSecurity
     @GetMapping("/kakao")
     public void kakaoLogin(HttpServletResponse response) throws IOException {
-        response.sendRedirect("/oauth2/authorization/kakao");
+        response.sendRedirect(StaticVariable.KAKAO_OAUTH2_AUTHORIZATION_URI);
     }
 
     /**

--- a/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
+++ b/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
@@ -1,0 +1,69 @@
+package com.example.demo.security.oauth.controller;
+
+import com.example.demo.api.common.dto.ApiResponseDto;
+import com.example.demo.common.annotation.DisableSwaggerSecurity;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Tag(name = "OAuth2 API", description = "소셜 로그인 API")
+@RestController
+@RequestMapping("/api/auth")
+public class OAuthController {
+
+    /**
+     * Swagger에서 클릭하면 카카오 OAuth2 로그인 페이지로 리다이렉트됩니다.
+     * 로그인 성공 후 oauth2.redirect-uri?accessToken=<token> 으로 리다이렉트됩니다.
+     */
+    @Operation(
+            summary = "카카오 로그인 시작",
+            description = """
+                    **[Swagger 카카오 로그인 테스트 방법]**
+                    1. 'Try it out' → 'Execute' 클릭
+                    2. 브라우저가 카카오 로그인 페이지로 이동합니다 (302 리다이렉트)
+                    3. 카카오 계정으로 로그인합니다
+                    4. 로그인 성공 시 `oauth2.redirect-uri?accessToken=<JWT>` 로 리다이렉트됩니다
+                    5. URL의 `accessToken` 값을 복사합니다
+                    6. Swagger 우상단 **Authorize** 버튼 클릭 → 복사한 토큰 붙여넣기 후 인증
+                    """
+    )
+    @DisableSwaggerSecurity
+    @GetMapping("/kakao")
+    public void kakaoLogin(HttpServletResponse response) throws IOException {
+        response.sendRedirect("/oauth2/authorization/kakao");
+    }
+
+    /**
+     * 로컬 테스트 전용: OAuth2 성공 후 리다이렉트되는 콜백 페이지
+     * application.yml의 oauth2.redirect-uri가 http://localhost:8080/oauth2/redirect 일 때 사용
+     */
+    @Operation(
+            summary = "OAuth2 콜백 (로컬 테스트용)",
+            description = """
+                    카카오 로그인 성공 후 리다이렉트되는 엔드포인트입니다.
+                    `accessToken` 파라미터에 JWT 액세스 토큰이 포함되어 있습니다.
+                    이 토큰을 복사해 Swagger의 Authorize에 입력하세요.
+                    """
+    )
+    @DisableSwaggerSecurity
+    @GetMapping("/kakao/callback")
+    public ApiResponseDto<Map<String, String>> kakaoCallback(
+            @Parameter(description = "OAuth2 성공 핸들러가 발급한 JWT 액세스 토큰")
+            @RequestParam(required = false) String accessToken) {
+        if (accessToken == null) {
+            return ApiResponseDto.onFailure(4001, "accessToken이 없습니다.", null);
+        }
+        log.info("카카오 로그인 콜백 - accessToken 발급 완료");
+        return ApiResponseDto.onSuccess(Map.of("accessToken", accessToken));
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth/dto/CustomUserDetails.java
+++ b/src/main/java/com/example/demo/security/oauth/dto/CustomUserDetails.java
@@ -1,0 +1,120 @@
+package com.example.demo.security.oauth.dto;
+
+import com.example.demo.domain.member.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomUserDetails implements OAuth2User, UserDetails {
+
+    private Long id;
+    private String username;
+    private String kakaoEmail;
+    private OAuth2AccessToken oAuth2AccessToken;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public CustomUserDetails(Long id,
+                             String username,
+                             String kakaoEmail,
+                             OAuth2AccessToken oAuth2AccessToken,
+                             Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.kakaoEmail = kakaoEmail;
+        this.oAuth2AccessToken = oAuth2AccessToken;
+        this.authorities = authorities;
+    }
+
+    public static CustomUserDetails create(Member member) {
+        List<GrantedAuthority> authorities = Collections.
+                singletonList(new SimpleGrantedAuthority(member.getRole().getKey()));
+
+        return new CustomUserDetails(
+                member.getId(),
+                member.getUsername(),
+                member.getKakaoEmail(),
+                null,
+                authorities
+        );
+    }
+
+    public static CustomUserDetails create(Member member, Map<String, Object> attributes) {
+        CustomUserDetails userDetails = CustomUserDetails.create(member);
+        userDetails.setAttributes(attributes);
+        return userDetails;
+    }
+
+    public static CustomUserDetails create(Member member, OAuth2AccessToken oAuth2AccessToken) {
+        List<GrantedAuthority> authorities = Collections.
+                singletonList(new SimpleGrantedAuthority(member.getRole().getKey()));
+
+        return new CustomUserDetails(
+                member.getId(),
+                member.getUsername(),
+                member.getKakaoEmail(),
+                oAuth2AccessToken,
+                authorities
+        );
+    }
+
+    //UserDetail override
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // OAuth2User Override
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth/dto/KakaoOAuth2User.java
+++ b/src/main/java/com/example/demo/security/oauth/dto/KakaoOAuth2User.java
@@ -1,0 +1,37 @@
+package com.example.demo.security.oauth.dto;
+
+import java.util.Map;
+
+public class KakaoOAuth2User extends OAuth2UserInfo {
+    private Long id;
+    private String nickname;
+    private String profileImg;
+
+    public KakaoOAuth2User(Map<String, Object> attributes) {
+        super((Map<String, Object>) attributes.get("kakao_account"));
+        this.id = (Long) attributes.get("id");
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        this.nickname = (String) profile.get("nickname");
+        this.profileImg = (String) profile.get("profile_image_url");
+    }
+
+    @Override
+    public String getOAuth2Id() {
+        return this.id.toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return this.nickname;
+    }
+
+    @Override
+    public String getProfileImg(){return this.profileImg;}
+
+}

--- a/src/main/java/com/example/demo/security/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/security/oauth/dto/OAuth2UserInfo.java
@@ -1,0 +1,21 @@
+package com.example.demo.security.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public abstract String getOAuth2Id();
+
+    public abstract String getEmail();
+
+    public abstract String getNickname();
+
+    public abstract String getProfileImg();
+}

--- a/src/main/java/com/example/demo/security/oauth/factory/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/example/demo/security/oauth/factory/OAuth2UserInfoFactory.java
@@ -1,0 +1,11 @@
+package com.example.demo.security.oauth.factory;
+
+import com.example.demo.security.oauth.dto.KakaoOAuth2User;
+
+import java.util.Map;
+//TODO: 구글, 네이버 같은 다른 소셜 로그인을 추가할 때 분기 처리하기 위해서 만든 구조
+public class OAuth2UserInfoFactory {
+    public static KakaoOAuth2User getOAuth2UserInfo(Map<String, Object> attributes) {
+        return new KakaoOAuth2User(attributes);
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginFailureHandler.java
@@ -17,6 +17,7 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
+        // TODO: 응답 형식을 ApiResponseDto 통일 형식에 맞게 filter 단위에서 처리하도록 개선
         log.error("OAuth2 로그인 실패: {}", exception.getMessage());
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,25 @@
+package com.example.demo.security.oauth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.error("OAuth2 로그인 실패: {}", exception.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"isSuccess\":false,\"code\":4001,\"message\":\"카카오 로그인에 실패했습니다.\"}");
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,48 @@
+package com.example.demo.security.oauth.handler;
+
+import com.example.demo.common.util.CookieUtil;
+import com.example.demo.security.jwt.dto.JwtToken;
+import com.example.demo.security.jwt.service.TokenService;
+import com.example.demo.security.oauth.dto.CustomUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final TokenService tokenService;
+    private final CookieUtil cookieUtil;
+
+    @Value("${oauth2.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        JwtToken jwtToken = tokenService.login(userDetails.getKakaoEmail());
+
+        // RefreshToken을 HttpOnly Cookie에 세팅
+        cookieUtil.setTokenResponse(response, jwtToken);
+
+        // AccessToken을 쿼리 파라미터로 담아 프론트엔드(또는 로컬 테스트 페이지)로 리다이렉트
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", jwtToken.getAccessToken())
+                .build().toUriString();
+
+        log.info("OAuth2 로그인 성공 - member: {}", userDetails.getKakaoEmail());
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/demo/security/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,61 @@
+package com.example.demo.security.oauth.service;
+
+import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.domain.member.entity.Member;
+import com.example.demo.domain.member.entity.Role;
+import com.example.demo.domain.member.repository.MemberRepository;
+import com.example.demo.security.oauth.dto.CustomUserDetails;
+import com.example.demo.security.oauth.dto.KakaoOAuth2User;
+import com.example.demo.security.oauth.factory.OAuth2UserInfoFactory;
+import com.example.demo.common.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import java.util.Optional;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final MemberRepository memberRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+        return processOAuth2User(oAuth2User, userRequest.getAccessToken());
+    }
+    protected OAuth2User processOAuth2User(OAuth2User oAuth2User, OAuth2AccessToken oAuth2AccessToken) {
+        //OAuth2 로그인 플랫폼 구분 과정 생략, 카카오에서 필요한 정보 가져오기(이메일)
+        KakaoOAuth2User oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2User.getAttributes());
+        if (!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
+            throw new GeneralException(ErrorStatus.AUTH_OAUTH2_EMAIL_NOT_FOUND_FROM_PROVIDER);
+        }
+        Optional<Member> byEmail = memberRepository.findByKakaoEmail(oAuth2UserInfo.getEmail());
+        Member member = byEmail.orElseGet(() -> registerMember(oAuth2UserInfo));
+
+        return CustomUserDetails.create(member, oAuth2AccessToken);
+    }
+
+    private Member registerMember(KakaoOAuth2User oAuth2UserInfo) {
+        Member register = Member.builder()
+                .kakaoEmail(oAuth2UserInfo.getEmail())
+                .username(oAuth2UserInfo.getNickname())
+                .profileImg(oAuth2UserInfo.getProfileImg())
+                .role(Role.USER)           //회원가입시에만 guest로 두고 이후 사용에는 user로 돌린다
+                .build();
+
+        return memberRepository.save(register);
+    }
+
+
+}


### PR DESCRIPTION
## 💡 관련 이슈
- Close #10 

## 🛠 작업 내용
**1. OAuth2 로그인 핸들러 추가**    
 - OAuth2LoginSuccessHandler — 카카오 로그인 성공 시 JWT 발급 후 oauth2.redirect-uri?accessToken=<JWT>로 리다이렉트                                                            
  - OAuth2LoginFailureHandler — 로그인 실패 시 JSON 에러 응답 반환

**2. Swagger 테스트용 OAuthController 추가**                                                                                                                                                                                                                                                                                                                  
  - `GET /api/auth/kakao`— Swagger에서 클릭하면 카카오 로그인 페이지로 리다이렉트                                                                                                
  - `GET /api/auth/kakao/callback` — 로그인 성공 후 accessToken을 JSON으로 반환 (Swagger 복붙용)       
                                                                                                                                             
**3. MemberController 추가**                                                                                                                                                    
- `GET /api/members/me` — JWT 인증 후 내 정보 조회 (CustomUserDetails에서 id 추출)

**4. 카카오에서 받아온 정보를 member에 매핑**

**5. 프론트 연동 시 사용할 cors 설정 추가(local)**

## ⚙️ 동작 흐름
**1. 카카오 로그인 요청**
- 사용자가 카카오 로그인을 진행하면 Spring Security의 OAuth2 흐름을 통해 인증이 수행된다.
- CustomOAuth2UserService에서 카카오 사용자 정보를 기반으로 DB에서 회원을 조회하거나 신규 생성한다.
 
**2. JWT 토큰 발급**
- OAuth2 로그인 성공 시 OAuth2LoginSuccessHandler에서 JWT 발급 로직이 실행된다.
- TokenService.login()을 통해 AccessToken과 RefreshToken을 생성한다.

**3. 토큰 생성 및 저장**
- AccessToken: 사용자 정보(subject, 권한)를 포함하며 30분 유효
- RefreshToken: subject만 포함하며 7일 유효
- RefreshToken은 Redis에 저장하여 관리 (화이트리스트 방식)

**4. 토큰 전달 방식**
- AccessToken: Authorization 헤더로 전달
- RefreshToken: HttpOnly Cookie로 전달

**5. API 요청 인증 처리**
- 이후 모든 요청은 JwtAuthenticationFilter에서 AccessToken을 검증
- 토큰이 유효하면 SecurityContext에 인증 정보를 저장하여 인가 처리

**6. 토큰 재발급**
- AccessToken 만료 시 RefreshToken을 사용해 재발급
- Redis에 저장된 RefreshToken 검증 후 새 토큰 발급 (기존 RefreshToken은 삭제)

**7. 로그아웃**
Redis에서 RefreshToken을 삭제하여 재사용을 방지

## 📸 결과 캡쳐화면
- 실행한 결과를 캡쳐하여 올려주세요.
<img width="1142" height="722" alt="스크린샷 2026-04-08 오후 7 36 38" src="https://github.com/user-attachments/assets/cdebcc3e-05b3-47c8-9450-3aaf55ad8059" />
<img width="585" height="644" alt="스크린샷 2026-04-08 오후 7 37 11" src="https://github.com/user-attachments/assets/9c0ce648-19b7-46e4-b9dd-78cf5e8c6042" />
<img width="1372" height="403" alt="스크린샷 2026-04-08 오후 7 37 26" src="https://github.com/user-attachments/assets/f41dd92b-4f9d-4029-a0f3-4889a59602d9" />
<img width="1187" height="763" alt="스크린샷 2026-04-08 오후 7 38 06" src="https://github.com/user-attachments/assets/8187d0ea-2286-4ed0-b297-f7db70802fbe" />
<img width="1163" height="718" alt="스크린샷 2026-04-08 오후 7 40 11" src="https://github.com/user-attachments/assets/4435e912-00ea-44c2-b475-3b726bb8fd1b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 OAuth2 로그인 시작 및 콜백 엔드포인트 추가 (/api/auth/kakao, /api/auth/kakao/callback)
  * 로그인 후 액세스 토큰 반환 및 HttpOnly 리프레시 토큰 쿠키 발급
  * 회원 정보 조회 API 경로 추가: GET /api/members/info

* **보안**
  * 역할 기반 권한(Role) 도입 및 권한 반환 방식 정비
  * OAuth2 로그인 흐름, 세션 정책 및 전역 CORS 설정 개선

* **문서화**
  * OpenAPI/Swagger에 대한 보안 처리 및 커스터마이징 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->