### PR TITLE
[feat] S3 spring 연동 및 종목코드/날짜 기준 S3 파일 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,14 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    //s3
+    implementation 'software.amazon.awssdk:s3:2.25.26'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
 
 
 }

--- a/src/main/java/com/example/demo/api/report/controller/ReportController.java
+++ b/src/main/java/com/example/demo/api/report/controller/ReportController.java
@@ -1,8 +1,15 @@
 package com.example.demo.api.report.controller;
 
+import com.example.demo.infra.S3.dto.S3Response;
+import com.example.demo.infra.S3.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "[사용자 리포트 페이지] 사용자 리포트 API")
@@ -10,4 +17,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/users/reports")
 @RequiredArgsConstructor
 public class ReportController {
+    private final S3Service S3Service;
+
+    @Operation(summary = "리포트 조회", description = "종목 코드와 날짜로 S3에 저장된 리포트 URL을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<S3Response> getReport(
+            @Parameter(description = "종목 코드 (예: 005930)") @RequestParam String stockCode,
+            @Parameter(description = "날짜 (예: 20240101)") @RequestParam String date
+    ) {
+
+        String url =
+                S3Service.getReportUrl(stockCode, date);
+
+        return ResponseEntity.ok(
+                new S3Response(
+                        stockCode,
+                        date,
+                        url
+                )
+        );
+    }
 }

--- a/src/main/java/com/example/demo/infra/S3/config/S3Config.java
+++ b/src/main/java/com/example/demo/infra/S3/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.example.demo.infra.S3.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/infra/S3/dto/S3Response.java
+++ b/src/main/java/com/example/demo/infra/S3/dto/S3Response.java
@@ -1,0 +1,13 @@
+package com.example.demo.infra.S3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class S3Response {
+
+    private String stockCode; //종목코드
+    private String date; //날짜
+    private String url;
+}

--- a/src/main/java/com/example/demo/infra/S3/exception/S3ErrorStatus.java
+++ b/src/main/java/com/example/demo/infra/S3/exception/S3ErrorStatus.java
@@ -1,0 +1,51 @@
+package com.example.demo.infra.S3.exception;
+
+import com.example.demo.common.annotation.ExplainError;
+import com.example.demo.common.exception.BaseErrorCode;
+import com.example.demo.common.exception.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public enum S3ErrorStatus implements BaseErrorCode {
+
+    // Infra S3(5050~5099)
+    S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, 5050, "요청한 리포트 파일을 찾을 수 없습니다."),
+    S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, 5051, "S3 접근 권한이 없습니다."),
+    S3_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5052, "S3 처리 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getMessage();
+    }
+}

--- a/src/main/java/com/example/demo/infra/S3/exception/S3Handler.java
+++ b/src/main/java/com/example/demo/infra/S3/exception/S3Handler.java
@@ -1,0 +1,15 @@
+package com.example.demo.infra.S3.exception;
+
+import com.example.demo.common.exception.BaseErrorCode;
+import com.example.demo.common.exception.GeneralException;
+
+public class S3Handler extends GeneralException {
+
+    public static final GeneralException FILE_NOT_FOUND = new S3Handler(S3ErrorStatus.S3_FILE_NOT_FOUND);
+    public static final GeneralException ACCESS_DENIED = new S3Handler(S3ErrorStatus.S3_ACCESS_DENIED);
+    public static final GeneralException INTERNAL_ERROR = new S3Handler(S3ErrorStatus.S3_INTERNAL_ERROR);
+
+    public S3Handler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/example/demo/infra/S3/service/S3Service.java
+++ b/src/main/java/com/example/demo/infra/S3/service/S3Service.java
@@ -1,0 +1,71 @@
+package com.example.demo.infra.S3.service;
+
+import com.example.demo.infra.S3.exception.S3Handler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String getReportUrl(String stockCode, String date) {
+        try {
+            ListObjectsV2Request request = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .build();
+
+            ListObjectsV2Response response = s3Client.listObjectsV2(request);
+
+            String key = response.contents().stream()
+                    .map(S3Object::key)
+                    .filter(fileName ->
+                            fileName.startsWith(stockCode + "_")
+                                    && fileName.contains("_" + date + "_analysis.html")
+                    )
+                    .findFirst()
+                    .orElseThrow(() -> S3Handler.FILE_NOT_FOUND);
+
+            GetObjectRequest getObjectRequest =
+                    GetObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .build();
+
+            GetObjectPresignRequest presignRequest =
+                    GetObjectPresignRequest.builder()
+                            .signatureDuration(Duration.ofMinutes(10))
+                            .getObjectRequest(getObjectRequest)
+                            .build();
+
+            PresignedGetObjectRequest presignedRequest =
+                    s3Presigner.presignGetObject(presignRequest);
+
+            return presignedRequest.url().toString();
+
+        } catch (S3Exception e) {
+            if (e.statusCode() == 403) throw S3Handler.ACCESS_DENIED;
+            throw S3Handler.INTERNAL_ERROR;
+        } catch (SdkClientException e) {
+            throw S3Handler.INTERNAL_ERROR;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,13 @@ oauth2:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000} # 기본값은 http://localhost:3000 (로컬 프론트), 운영/배포 시 환경변수 CORS_ALLOWED_ORIGINS로 주입
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,4 +57,4 @@ cloud:
     region:
       static: ${AWS_REGION}
     s3:
-      bucket: ${S3_BUCKET}
+      bucket: ${S3_BUCKET} #http가 아니고 treat이기 때문에 base url쪽 수정


### PR DESCRIPTION
## 💡 관련 이슈
- Close #21 

## 🛠 작업 내용
- 어떤 작업을 했는지 요약해서 적어주세요.
- 종목코드/날짜 기준 S3 파일 조회 API 구현
- S3 config, errorcode 정리
# 📸 결과 캡쳐화면
- 실행한 결과를 캡쳐하여 올려주세요.
<img width="1346" height="629" alt="스크린샷 2026-05-16 오후 6 21 19" src="https://github.com/user-attachments/assets/9c98d4d7-52b9-48df-a6a7-331abab60495" />
<img width="1299" height="513" alt="스크린샷 2026-05-16 오후 6 21 36" src="https://github.com/user-attachments/assets/28ea518d-5a28-4478-a20f-2062309d2cfb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리포트 조회 API 엔드포인트 추가 (/api/v1/users/reports) — 주식 코드와 날짜로 저장된 리포트 접근 및 presigned URL 반환
  * API에 Swagger/OpenAPI 문서화 추가

* **Chores**
  * AWS S3 연동 설정 및 자격정보/리전/버킷 설정 추가

* **Bug Fixes**
  * S3 접근/내부 오류에 대한 명확한 오류 처리 및 매핑 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TREAT-st/TREAT_BackEnd/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->