### PR TITLE
♻️ [REFACTOR] refresh token 응답 추가 및 카카오 로그인 배포 오류 수정

### DIFF
--- a/src/main/java/com/example/demo/common/exception/ErrorStatus.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorStatus.java
@@ -54,6 +54,8 @@ public enum ErrorStatus implements BaseErrorCode{
     AUTH_TOKEN_IS_UNSUPPORTED(UNAUTHORIZED, 4358, "지원하지 않는 토큰 형식입니다."),
     @ExplainError("토큰 값이 비어있습니다.")
     AUTH_IS_NULL(UNAUTHORIZED, 4359, "토큰이 존재하지 않습니다."),
+    @ExplainError("일회용 인증 코드가 만료되었거나 유효하지 않습니다. 카카오 로그인을 다시 시도해주세요.")
+    AUTH_INVALID_AUTH_CODE(UNAUTHORIZED, 4360, "유효하지 않은 인증 코드입니다. 다시 로그인해주세요."),
 
     // member (4050~4099)
     @ExplainError("존재하지 않는 NameType 입니다.")

--- a/src/main/java/com/example/demo/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/demo/common/exception/ExceptionAdvice.java
@@ -1,0 +1,26 @@
+package com.example.demo.common.exception;
+
+import com.example.demo.api.common.dto.ApiResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponseDto<?>> handleGeneralException(
+            GeneralException e
+    ) {
+
+        Reason reason = e.getErrorReasonHttpStatus();
+
+        return ResponseEntity
+                .status(reason.getHttpStatus())
+                .body(ApiResponseDto.onFailure(
+                        reason.getCode(),
+                        reason.getMessage(),
+                        null
+                ));
+    }
+}

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -34,4 +34,5 @@ public class RedisService {
         }
         redisTemplate.delete(token);
     }
+
 }

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -35,4 +35,21 @@ public class RedisService {
         redisTemplate.delete(token);
     }
 
+    // FOR OAuth2 일회용 auth code (whiteList)
+    private static final String AUTH_CODE_PREFIX = "auth:code:";
+
+    public void setAuthCode(String code, String username) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(AUTH_CODE_PREFIX + code, username, Duration.ofMinutes(3));
+    }
+
+    public String getAuthCode(String code) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(AUTH_CODE_PREFIX + code);
+    }
+
+    public void deleteAuthCode(String code) {
+        redisTemplate.delete(AUTH_CODE_PREFIX + code);
+    }
+
 }

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                                 "/api/tokens/logout",
                                 "/api/auth/kakao",
                                 "/api/auth/kakao/callback",
+                                "/api/auth/token",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -61,8 +61,7 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/api/v1/test/health-check",
-                                "/api/v1/users"
+                                "/api/v1/test/health-check"
                         ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/com/example/demo/security/controller/TokenApiController.java
+++ b/src/main/java/com/example/demo/security/controller/TokenApiController.java
@@ -2,24 +2,17 @@ package com.example.demo.security.controller;
 
 import com.example.demo.api.common.dto.ApiResponseDto;
 import com.example.demo.common.annotation.DisableSwaggerSecurity;
-import com.example.demo.common.exception.ErrorStatus;
-import com.example.demo.common.exception.GeneralException;
-import com.example.demo.common.util.CookieUtil;
-import com.example.demo.security.filter.JwtAuthenticationFilter;
 import com.example.demo.security.jwt.dto.AccessTokenResponse;
 import com.example.demo.security.jwt.dto.JwtToken;
+import com.example.demo.security.jwt.dto.RefreshTokenRequest;
 import com.example.demo.security.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
-
-import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE;
 
 @Tag(name = "Token API", description = "토큰 API")
 @ApiResponse(responseCode = "2000", description = "성공")
@@ -28,47 +21,41 @@ import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE
 @RestController
 public class TokenApiController {
 
-    private final CookieUtil cookieUtil;
     private final TokenService tokenService;
 
     @Operation(
             summary = "로그인(토큰 생성)",
-            description = "카카오 이메일로 로그인합니다. AccessToken은 헤더(Authorization)와 바디로, RefreshToken은 HttpOnly Cookie로 전달됩니다."
+            description = "카카오 이메일로 로그인합니다. AccessToken, RefreshToken 둘 다 body로 전달됩니다."
     )
     @DisableSwaggerSecurity
     @GetMapping("/login")
-    public ApiResponseDto<AccessTokenResponse>  login(@RequestParam String kakaoEmail,
+    public ApiResponseDto<AccessTokenResponse> login(@RequestParam String kakaoEmail,
                                                      HttpServletResponse response) {
         JwtToken jwtToken = tokenService.login(kakaoEmail);
-        cookieUtil.setTokenResponse(response, jwtToken);
-        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
+        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken(), jwtToken.getRefreshToken()));
     }
 
     @Operation(
             summary = "토큰 재발행",
-            description = "Cookie의 RefreshToken으로 새 AccessToken을 발급합니다. AccessToken은 헤더(Authorization)와 바디로, 새 RefreshToken은 Cookie로 전달됩니다."
+            description = "body의 RefreshToken으로 새 AccessToken을 발급합니다. AccessToken은 헤더(Authorization)와 body로 전달됩니다."
     )
     @DisableSwaggerSecurity
     @PostMapping("/reissue")
-    public ApiResponseDto<AccessTokenResponse> reissue(HttpServletRequest request,
+    public ApiResponseDto<AccessTokenResponse> reissue(@RequestBody RefreshTokenRequest request,
                                                        HttpServletResponse response) {
-        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(request);
-        JwtToken jwtToken = tokenService.issueTokens(refreshToken);
-        cookieUtil.setTokenResponse(response, jwtToken);
-        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken()));
+        JwtToken jwtToken = tokenService.issueTokens(request.getRefreshToken());
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
+        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken(), jwtToken.getRefreshToken()));
     }
 
     @Operation(
             summary = "로그아웃",
-            description = "Cookie의 RefreshToken을 삭제하고 Redis에서 제거합니다."
+            description = "헤더(Authorization)의 AccessToken과 body의 RefreshToken을 받아 Redis에서 RefreshToken을 제거합니다."
     )
     @PostMapping("/logout")
-    public ApiResponseDto<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(request);
-        tokenService.logout(refreshToken);
-        cookieUtil.expireRefreshTokenCookie(response);
+    public ApiResponseDto<Void> logout(@RequestBody RefreshTokenRequest request) {
+        tokenService.logout(request.getRefreshToken());
         return ApiResponseDto.onSuccess(null);
     }
-
-
 }

--- a/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/filter/JwtAuthenticationFilter.java
@@ -1,13 +1,8 @@
 package com.example.demo.security.filter;
 
-import com.example.demo.common.exception.ErrorStatus;
-import com.example.demo.common.exception.GeneralException;
-import com.example.demo.common.util.CookieUtil;
-import com.example.demo.security.jwt.dto.JwtToken;
 import com.example.demo.security.jwt.service.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +16,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,7 +23,6 @@ import static com.example.demo.common.consts.StaticVariable.REFRESH_TOKEN_COOKIE
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenService tokenService;
-    private final CookieUtil cookieUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/example/demo/security/jwt/dto/AccessTokenResponse.java
+++ b/src/main/java/com/example/demo/security/jwt/dto/AccessTokenResponse.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AccessTokenResponse {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/example/demo/security/jwt/dto/AuthCodeRequest.java
+++ b/src/main/java/com/example/demo/security/jwt/dto/AuthCodeRequest.java
@@ -1,0 +1,10 @@
+package com.example.demo.security.jwt.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthCodeRequest {
+    private String code;
+}

--- a/src/main/java/com/example/demo/security/jwt/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/example/demo/security/jwt/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.example.demo.security.jwt.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/example/demo/security/jwt/service/TokenService.java
+++ b/src/main/java/com/example/demo/security/jwt/service/TokenService.java
@@ -9,6 +9,7 @@ public interface TokenService {
 
     JwtToken login(String kakaoEmail);
     JwtToken issueTokens(String refreshToken);
+    JwtToken issueTokensByAuthCode(String code);
 
     JwtToken generateToken(Authentication authentication);
 

--- a/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.demo.security.jwt.service;
 
 import com.example.demo.common.exception.ErrorStatus;
+import com.example.demo.common.exception.GeneralException;
 import com.example.demo.common.service.RedisService;
 import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.service.UserQueryService;
@@ -47,6 +48,21 @@ public class TokenServiceImpl implements TokenService{
     @Override       //TODO oauth2적용시 필요 없음
     public JwtToken login(String kakaoEmail) {
         User user = userQueryService.getUserByKakaoEmail(kakaoEmail);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user, "",
+                user.getAuthorities());
+        return generateToken(authentication);
+    }
+
+    @Override
+    public JwtToken issueTokensByAuthCode(String code) {
+        String username = redisService.getAuthCode(code);
+        if (username == null) {
+            throw new GeneralException(ErrorStatus.AUTH_INVALID_AUTH_CODE);
+        }
+        // 일회용 - 즉시 삭제
+        redisService.deleteAuthCode(code);
+
+        User user = userQueryService.getUserByUsername(username);
         Authentication authentication = new UsernamePasswordAuthenticationToken(user, "",
                 user.getAuthorities());
         return generateToken(authentication);

--- a/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/example/demo/security/jwt/service/TokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.demo.security.jwt.service;
 
 import com.example.demo.common.exception.ErrorStatus;
-import com.example.demo.common.exception.GeneralException;
 import com.example.demo.common.service.RedisService;
 import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.service.UserQueryService;
@@ -57,7 +56,7 @@ public class TokenServiceImpl implements TokenService{
     public JwtToken issueTokens(String refreshToken) {
         // Refresh Token 유효성 검사
         if (!validateToken(refreshToken) || !existsRefreshToken(refreshToken)) {
-            throw new GeneralException(ErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
+            throw new JwtAuthenticationException(ErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
         }
 
         // 이전 리프레시 토큰 삭제
@@ -169,6 +168,7 @@ public class TokenServiceImpl implements TokenService{
         redisService.deleteValue(refreshToken);
         return true;
     }
+
 
     @Override
     public boolean existsRefreshToken(String refreshToken) {

--- a/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
+++ b/src/main/java/com/example/demo/security/oauth/controller/OAuthController.java
@@ -3,28 +3,32 @@ package com.example.demo.security.oauth.controller;
 import com.example.demo.api.common.dto.ApiResponseDto;
 import com.example.demo.common.annotation.DisableSwaggerSecurity;
 import com.example.demo.common.consts.StaticVariable;
+import com.example.demo.security.jwt.dto.AccessTokenResponse;
+import com.example.demo.security.jwt.dto.AuthCodeRequest;
+import com.example.demo.security.jwt.dto.JwtToken;
+import com.example.demo.security.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Slf4j
 @Tag(name = "OAuth2 API", description = "소셜 로그인 API")
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class OAuthController {
+
+    private final TokenService tokenService;
 
     /**
      * Swagger에서 클릭하면 카카오 OAuth2 로그인 페이지로 리다이렉트됩니다.
-     * 로그인 성공 후 oauth2.redirect-uri?accessToken=<token> 으로 리다이렉트됩니다.
+     * 로그인 성공 후 treat://oauth/kakao?code=<uuid> 로 리다이렉트됩니다.
      */
     @Operation(
             summary = "카카오 로그인 시작",
@@ -33,9 +37,8 @@ public class OAuthController {
                     1. 'Try it out' → 'Execute' 클릭
                     2. 브라우저가 카카오 로그인 페이지로 이동합니다 (302 리다이렉트)
                     3. 카카오 계정으로 로그인합니다
-                    4. 로그인 성공 시 `oauth2.redirect-uri?accessToken=<JWT>` 로 리다이렉트됩니다
-                    5. URL의 `accessToken` 값을 복사합니다
-                    6. Swagger 우상단 **Authorize** 버튼 클릭 → 복사한 토큰 붙여넣기 후 인증
+                    4. 로그인 성공 시 `treat://oauth/kakao?code=<UUID>` 로 리다이렉트됩니다
+                    5. 받은 `code` 값으로 `/api/auth/token` 을 호출해 accessToken/refreshToken을 발급받으세요
                     """
     )
     @DisableSwaggerSecurity
@@ -44,27 +47,20 @@ public class OAuthController {
         response.sendRedirect(StaticVariable.KAKAO_OAUTH2_AUTHORIZATION_URI);
     }
 
-//    /**
-//     * 로컬 테스트 전용: OAuth2 성공 후 리다이렉트되는 콜백 페이지
-//     * application.yml의 oauth2.redirect-uri가 http://localhost:8080/oauth2/redirect 일 때 사용
-//     */
-//    @Operation(
-//            summary = "OAuth2 콜백 (로컬 테스트용)",
-//            description = """
-//                    카카오 로그인 성공 후 리다이렉트되는 엔드포인트입니다.
-//                    `accessToken` 파라미터에 JWT 액세스 토큰이 포함되어 있습니다.
-//                    이 토큰을 복사해 Swagger의 Authorize에 입력하세요.
-//                    """
-//    )
-//    @DisableSwaggerSecurity
-//    @GetMapping("/kakao/callback")
-//    public ApiResponseDto<Map<String, String>> kakaoCallback(
-//            @Parameter(description = "OAuth2 성공 핸들러가 발급한 JWT 액세스 토큰")
-//            @RequestParam(required = false) String accessToken) {
-//        if (accessToken == null) {
-//            return ApiResponseDto.onFailure(4001, "accessToken이 없습니다.", null);
-//        }
-//        log.info("카카오 로그인 콜백 - accessToken 발급 완료");
-//        return ApiResponseDto.onSuccess(Map.of("accessToken", accessToken));
-//    }
+    @Operation(
+            summary = "일회용 code로 토큰 발급",
+            description = """
+                    카카오 로그인 성공 후 딥링크로 전달된 일회용 `code`를 교환해 AccessToken/RefreshToken을 발급합니다.
+                    - code는 **3분** 유효, **1회만** 사용 가능합니다.
+                    - 만료 또는 재사용 시 4360 에러가 반환됩니다.
+                    """
+    )
+    @DisableSwaggerSecurity
+    @PostMapping("/token")
+    public ApiResponseDto<AccessTokenResponse> exchangeToken(@RequestBody AuthCodeRequest request,
+                                                             HttpServletResponse response) {
+        JwtToken jwtToken = tokenService.issueTokensByAuthCode(request.getCode());
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken.getAccessToken());
+        return ApiResponseDto.onSuccess(new AccessTokenResponse(jwtToken.getAccessToken(), jwtToken.getRefreshToken()));
+    }
 }

--- a/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/demo/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,39 +1,49 @@
 package com.example.demo.security.oauth.handler;
 
-import com.example.demo.security.jwt.dto.JwtToken;
-import com.example.demo.security.jwt.service.TokenService;
+import com.example.demo.common.service.RedisService;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.service.UserQueryService;
 import com.example.demo.security.oauth.dto.CustomUserDetails;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final TokenService tokenService;
-    private final ObjectMapper objectMapper;
+    private final RedisService redisService;
+    private final UserQueryService userQueryService;
+    private final String redirectUri;
+
+    public OAuth2LoginSuccessHandler(RedisService redisService,
+                                     UserQueryService userQueryService,
+                                     @Value("${oauth2.redirect-uri}") String redirectUri) {
+        this.redisService = redisService;
+        this.userQueryService = userQueryService;
+        this.redirectUri = redirectUri;
+    }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        JwtToken jwtToken = tokenService.login(userDetails.getKakaoEmail());
+        User user = userQueryService.getUserByKakaoEmail(userDetails.getKakaoEmail());
 
-        log.info("OAuth2 로그인 성공 - member: {}", userDetails.getKakaoEmail());
+        // 일회용 auth code 생성 후 Redis에 저장 (TTL 3분)
+        String authCode = UUID.randomUUID().toString();
+        redisService.setAuthCode(authCode, user.getUsername());
 
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("UTF-8");
-        objectMapper.writeValue(response.getWriter(), jwtToken);
+        log.info("OAuth2 로그인 성공 - member: {}, redirect: {}?code={}", userDetails.getKakaoEmail(), redirectUri, authCode);
+
+        response.sendRedirect(redirectUri + "?code=" + authCode);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ app:
     secret: ${JWT_SECRET}
 
 oauth2:
-  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:8080/api/auth/kakao/callback}
+  redirect-uri: ${OAUTH2_REDIRECT_URI:treat://oauth/kakao}
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000} # 기본값은 http://localhost:3000 (로컬 프론트), 운영/배포 시 환경변수 CORS_ALLOWED_ORIGINS로 주입


### PR DESCRIPTION
## 💡 관련 이슈
- Close #24 

## 🛠 작업 내용
- 자체로그인 accesstoken, refreshtoken 둘 다 response body에 넣는 작업
- 프론트(React Native)의 딥링크 방식에 맞게 변경하되, 토큰을 URL 쿼리 파라미터에 직접 노출하는 대신 일회용 code를 경유하는 보안 강화 방식으로 구현

## 🔗 인증 플로우
                           
1. RN 앱에서 WebBrowser.openAuthSessionAsync()를 통해 /api/auth/kakao 호출
2. 서버에서 카카오 OAuth 로그인 페이지로 리다이렉트
3. 카카오 로그인 성공 시 Spring Security OAuth2 인증 및 사용자 정보 조회/저장 수행
4. OAuth2LoginSuccessHandler에서 UUID 기반 일회용 auth code 생성
5. Redis에 `auth:code:<uuid> = username` 형식으로 저장 (TTL 3분)
6. `treat://oauth/kakao?code=<uuid>` 형태로 RN 앱에 Deep Link 리다이렉트
7. RN 앱에서 auth code 추출 후 `/api/auth/token` API 호출
8. 서버에서 Redis 기반 auth code 검증 및 즉시 삭제하여 일회용 보장
9. accessToken / refreshToken 발급 및 refreshToken Redis 화이트리스트 저장
10. 만료되거나 유효하지 않은 auth code 예외 처리 추가 (`AUTH_INVALID_AUTH_CODE`)

# 📸 결과 캡쳐화면
<img width="2220" height="1316" alt="image" src="https://github.com/user-attachments/assets/d35b9631-45e3-42e1-a164-1d2a34f39bb0" />
<img width="2166" height="134" alt="image" src="https://github.com/user-attachments/assets/db9731ea-7748-4b64-ae04-3a9daf22c23f" />
-> 앱 스킴 redirect는 swagger에서 정상테스트 불가하므로 log.info로 터미널에서 확인 가능. `redirectUri`
( expo-web-browser의 openAuthSessionAsync 라이브러리를 사용하면 인앱브라우저가 treat:// 리다이렉트 감지 → 자동으로 앱으로 복귀 된다고 합니다..? // 추후 프론트 공유 예정)

<img width="2208" height="1528" alt="image" src="https://github.com/user-attachments/assets/030a8cc4-cc0e-4bef-9a4a-30c6cca6ec54" />
<img width="2186" height="1100" alt="image" src="https://github.com/user-attachments/assets/1feb8561-ddcf-4d95-b018-ab2e5313b27d" />


<img width="2192" height="1138" alt="image" src="https://github.com/user-attachments/assets/f40246be-f18f-4368-845c-c13239e29c4e" />
-> code 만료(3분 지남) 또는 재사용 시 4360 에러가 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일회용 인증 코드 기반 OAuth2 로그인 플로우 추가
  * 토큰 응답에 리프레시 토큰 포함

* **Refactor**
  * 토큰 전달 메커니즘을 쿠키에서 HTTP 헤더 및 요청/응답 바디로 변경
  * 중앙화된 예외 처리 핸들러 추가
  * 리프레시 토큰 및 로그아웃 엔드포인트 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TREAT-st/TREAT_BackEnd/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->