### PR TITLE
[Feat] 변동성 리포트 생성 및 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.25.26'
 
+    // AWS Lambda
+    implementation 'software.amazon.awssdk:lambda:2.25.26'
+    implementation 'software.amazon.awssdk:apache-client:2.25.26'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/demo/api/kis/exception/KisErrorStatus.java
+++ b/src/main/java/com/example/demo/api/kis/exception/KisErrorStatus.java
@@ -1,4 +1,4 @@
-package com.example.demo.domain.volatility.exception;
+package com.example.demo.api.kis.exception;
 
 import com.example.demo.common.annotation.ExplainError;
 import com.example.demo.common.exception.BaseErrorCode;
@@ -12,17 +12,12 @@ import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
-public enum VolatilityErrorStatus implements BaseErrorCode {
+public enum KisErrorStatus implements BaseErrorCode {
 
-    // Entity Volatility(4300~4349)
-    // KRX 연동 오류는 KrxErrorStatus(4450~4499)로 분리했다.
-    VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다."),
-    @ExplainError("오늘 /detect를 실행하지 않아 리포트를 생성할 대상 종목이 없습니다.")
-    VOLATILITY_NOT_DETECTED_TODAY(HttpStatus.BAD_REQUEST, 4301, "오늘 탐지된 변동성 종목이 없습니다. 먼저 변동성 탐지를 실행해주세요."),
-    REPORT_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4302, "리포트 생성 Lambda 호출에 실패했습니다."),
-    @ExplainError("콜백 시크릿 헤더(X-Callback-Secret)가 없거나 일치하지 않습니다.")
-    REPORT_CALLBACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4303, "리포트 콜백 인증에 실패했습니다."),
-    REPORT_CALLBACK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4304, "리포트 콜백 요청 형식이 올바르지 않습니다.");
+    // KIS 연동(4400~4449)
+    KIS_API_ERROR(HttpStatus.BAD_GATEWAY, 4400, "KIS API 호출에 실패했습니다."),
+    @ExplainError("KIS가 응답은 했으나 조회 결과가 비어 있습니다. 휴장일이거나 거래 정지 종목일 수 있습니다.")
+    KIS_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4401, "KIS API 응답에 데이터가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/api/kis/exception/KisHandler.java
+++ b/src/main/java/com/example/demo/api/kis/exception/KisHandler.java
@@ -1,0 +1,19 @@
+package com.example.demo.api.kis.exception;
+
+import com.example.demo.common.exception.BaseErrorCode;
+import com.example.demo.common.exception.GeneralException;
+
+public class KisHandler extends GeneralException {
+
+    public KisHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+
+    public static KisHandler kisApiError() {
+        return new KisHandler(KisErrorStatus.KIS_API_ERROR);
+    }
+
+    public static KisHandler kisResponseEmpty() {
+        return new KisHandler(KisErrorStatus.KIS_RESPONSE_EMPTY);
+    }
+}

--- a/src/main/java/com/example/demo/api/kis/service/KisService.java
+++ b/src/main/java/com/example/demo/api/kis/service/KisService.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -42,8 +40,12 @@ public class KisService {
                     "0"
             );
 
-            if (response == null || !"0".equals(response.getRtCd())) {
-                log.error("KIS API 응답 오류. rt_cd={}, msg={}", Objects.requireNonNull(response).getRtCd(), response.getMsg1());
+            if (response == null) {
+                log.error("KIS API 응답이 비어있습니다. stockCode={}", stockCode);
+                throw StockHandler.kisApiError();
+            }
+            if (!"0".equals(response.getRtCd())) {
+                log.error("KIS API 응답 오류. rt_cd={}, msg={}", response.getRtCd(), response.getMsg1());
                 throw StockHandler.kisApiError();
             }
 

--- a/src/main/java/com/example/demo/api/kis/service/KisService.java
+++ b/src/main/java/com/example/demo/api/kis/service/KisService.java
@@ -2,7 +2,7 @@ package com.example.demo.api.kis.service;
 
 import com.example.demo.api.kis.client.KisFeignClient;
 import com.example.demo.api.kis.dto.KisResponseDto;
-import com.example.demo.domain.stock.exception.StockHandler;
+import com.example.demo.api.kis.exception.KisHandler;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,18 +42,18 @@ public class KisService {
 
             if (response == null) {
                 log.error("KIS API 응답이 비어있습니다. stockCode={}", stockCode);
-                throw StockHandler.kisApiError();
+                throw KisHandler.kisApiError();
             }
             if (!"0".equals(response.getRtCd())) {
                 log.error("KIS API 응답 오류. rt_cd={}, msg={}", response.getRtCd(), response.getMsg1());
-                throw StockHandler.kisApiError();
+                throw KisHandler.kisApiError();
             }
 
             return response;
 
         } catch (FeignException e) {
             log.error("KIS API 호출 실패. status={}, stockCode={}", e.status(), stockCode);
-            throw StockHandler.kisApiError();
+            throw KisHandler.kisApiError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/kis/service/KisService.java
+++ b/src/main/java/com/example/demo/api/kis/service/KisService.java
@@ -42,7 +42,7 @@ public class KisService {
 
             if (response == null) {
                 log.error("KIS API 응답이 비어있습니다. stockCode={}", stockCode);
-                throw KisHandler.kisApiError();
+                throw KisHandler.kisResponseEmpty();
             }
             if (!"0".equals(response.getRtCd())) {
                 log.error("KIS API 응답 오류. rt_cd={}, msg={}", response.getRtCd(), response.getMsg1());

--- a/src/main/java/com/example/demo/api/kis/service/KisTokenService.java
+++ b/src/main/java/com/example/demo/api/kis/service/KisTokenService.java
@@ -5,7 +5,7 @@ import com.example.demo.api.kis.dto.KisTokenRequestDto;
 import com.example.demo.api.kis.dto.KisTokenResponseDto;
 import com.example.demo.common.service.RedisService;
 import com.example.demo.common.util.RedisUtil;
-import com.example.demo.domain.stock.exception.StockHandler;
+import com.example.demo.api.kis.exception.KisHandler;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +48,7 @@ public class KisTokenService {
 
             if (tokenResponse == null || tokenResponse.getAccessToken() == null
                     || tokenResponse.getAccessToken().isBlank()) {
-                throw StockHandler.kisApiError();
+                throw KisHandler.kisApiError();
             }
 
             String token = tokenResponse.getAccessToken();
@@ -60,7 +60,7 @@ public class KisTokenService {
 
         } catch (FeignException e) {
             log.error("KIS 토큰 발급 실패. status={}", e.status());
-            throw StockHandler.kisApiError();
+            throw KisHandler.kisApiError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/krx/client/KrxLambdaClient.java
+++ b/src/main/java/com/example/demo/api/krx/client/KrxLambdaClient.java
@@ -1,12 +1,15 @@
 package com.example.demo.api.krx.client;
 
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
+import com.example.demo.api.krx.exception.KrxHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -18,6 +21,7 @@ import java.util.Map;
  * Lambda 함수 자체는 이 프로젝트가 아니라 별도로 배포된다 — 이 클라이언트는 그 함수의
  * 요청/응답 계약({@link KrxOhlcvResponseDto})에 맞춰 호출만 담당한다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KrxLambdaClient {
@@ -33,6 +37,7 @@ public class KrxLambdaClient {
         try {
             payload = objectMapper.writeValueAsString(Map.of("top", topN));
         } catch (JsonProcessingException e) {
+            // 고정 구조라 실패할 수 없다. 발생했다면 우리 코드 버그이므로 500으로 내보낸다.
             throw new IllegalStateException("KRX Lambda 요청 페이로드 생성 실패", e);
         }
 
@@ -41,18 +46,25 @@ public class KrxLambdaClient {
                 .payload(SdkBytes.fromUtf8String(payload))
                 .build();
 
-        InvokeResponse response = lambdaClient.invoke(request);
+        InvokeResponse response;
+        try {
+            response = lambdaClient.invoke(request);
+        } catch (SdkException e) {
+            log.error("KRX Lambda 호출 실패. functionName={}, topN={}", functionName, topN, e);
+            throw KrxHandler.krxLambdaInvokeError();
+        }
 
         if (response.functionError() != null) {
-            throw new IllegalStateException(
-                    "KRX Lambda 실행 오류: " + response.functionError()
-                            + ", payload=" + response.payload().asUtf8String());
+            log.error("KRX Lambda 실행 오류. functionError={}, payload={}",
+                    response.functionError(), response.payload().asUtf8String());
+            throw KrxHandler.krxLambdaExecutionError();
         }
 
         try {
             return objectMapper.readValue(response.payload().asUtf8String(), KrxOhlcvResponseDto.class);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("KRX Lambda 응답 파싱 실패", e);
+            log.error("KRX Lambda 응답 파싱 실패. payload={}", response.payload().asUtf8String(), e);
+            throw KrxHandler.krxLambdaResponseParseError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/krx/client/KrxLambdaClient.java
+++ b/src/main/java/com/example/demo/api/krx/client/KrxLambdaClient.java
@@ -1,0 +1,58 @@
+package com.example.demo.api.krx.client;
+
+import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+import java.util.Map;
+
+/**
+ * KOSPI 시총 상위 종목의 OHLCV를 pykrx로 조회하는 AWS Lambda(별도 배포)를 호출하는 클라이언트.
+ * Lambda 함수 자체는 이 프로젝트가 아니라 별도로 배포된다 — 이 클라이언트는 그 함수의
+ * 요청/응답 계약({@link KrxOhlcvResponseDto})에 맞춰 호출만 담당한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class KrxLambdaClient {
+
+    private final LambdaClient lambdaClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${krx.lambda.function-name}")
+    private String functionName;
+
+    public KrxOhlcvResponseDto invokeGetTopMarketCapOhlcv(int topN) {
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(Map.of("top", topN));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("KRX Lambda 요청 페이로드 생성 실패", e);
+        }
+
+        InvokeRequest request = InvokeRequest.builder()
+                .functionName(functionName)
+                .payload(SdkBytes.fromUtf8String(payload))
+                .build();
+
+        InvokeResponse response = lambdaClient.invoke(request);
+
+        if (response.functionError() != null) {
+            throw new IllegalStateException(
+                    "KRX Lambda 실행 오류: " + response.functionError()
+                            + ", payload=" + response.payload().asUtf8String());
+        }
+
+        try {
+            return objectMapper.readValue(response.payload().asUtf8String(), KrxOhlcvResponseDto.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("KRX Lambda 응답 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/api/krx/dto/KrxOhlcvResponseDto.java
+++ b/src/main/java/com/example/demo/api/krx/dto/KrxOhlcvResponseDto.java
@@ -1,0 +1,65 @@
+package com.example.demo.api.krx.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * KRX(pykrx) 기반 시총 상위 OHLCV 조회 Lambda의 응답 계약.
+ * 유효 거래일 20일 미만 등으로 제외된 종목은 stocks에서 빠지고 errors에 사유가 담긴다(종목별 실패 격리).
+ * Lambda가 이미 정제(0값 행 제거)·트리밍(최근 60거래일)까지 마친 배열을 내려주므로
+ * Java 쪽은 별도 가공 없이 바로 지표 계산에 사용한다.
+ */
+@Getter
+@NoArgsConstructor
+public class KrxOhlcvResponseDto {
+
+    @JsonProperty("effective_trade_date")
+    private String effectiveTradeDate;
+
+    @JsonProperty("universe_size")
+    private int universeSize;
+
+    @JsonProperty("stocks")
+    private List<StockOhlcv> stocks;
+
+    @JsonProperty("errors")
+    private List<ErrorItem> errors;
+
+    @Getter
+    @NoArgsConstructor
+    public static class StockOhlcv {
+        @JsonProperty("stock_code")
+        private String stockCode;
+
+        @JsonProperty("stock_name")
+        private String stockName;
+
+        @JsonProperty("market_cap_rank")
+        private int marketCapRank;
+
+        @JsonProperty("close")
+        private double[] close;
+
+        @JsonProperty("high")
+        private double[] high;
+
+        @JsonProperty("low")
+        private double[] low;
+
+        @JsonProperty("volume")
+        private double[] volume;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ErrorItem {
+        @JsonProperty("stock_code")
+        private String stockCode;
+
+        @JsonProperty("reason")
+        private String reason;
+    }
+}

--- a/src/main/java/com/example/demo/api/krx/exception/KrxErrorStatus.java
+++ b/src/main/java/com/example/demo/api/krx/exception/KrxErrorStatus.java
@@ -1,4 +1,4 @@
-package com.example.demo.domain.volatility.exception;
+package com.example.demo.api.krx.exception;
 
 import com.example.demo.common.annotation.ExplainError;
 import com.example.demo.common.exception.BaseErrorCode;
@@ -12,17 +12,12 @@ import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
-public enum VolatilityErrorStatus implements BaseErrorCode {
+public enum KrxErrorStatus implements BaseErrorCode {
 
-    // Entity Volatility(4300~4349)
-    // KRX 연동 오류는 KrxErrorStatus(4450~4499)로 분리했다.
-    VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다."),
-    @ExplainError("오늘 /detect를 실행하지 않아 리포트를 생성할 대상 종목이 없습니다.")
-    VOLATILITY_NOT_DETECTED_TODAY(HttpStatus.BAD_REQUEST, 4301, "오늘 탐지된 변동성 종목이 없습니다. 먼저 변동성 탐지를 실행해주세요."),
-    REPORT_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4302, "리포트 생성 Lambda 호출에 실패했습니다."),
-    @ExplainError("콜백 시크릿 헤더(X-Callback-Secret)가 없거나 일치하지 않습니다.")
-    REPORT_CALLBACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4303, "리포트 콜백 인증에 실패했습니다."),
-    REPORT_CALLBACK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4304, "리포트 콜백 요청 형식이 올바르지 않습니다.");
+    // KRX 연동(4450~4499)
+    KRX_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4450, "KRX 종목 조회 Lambda 호출에 실패했습니다."),
+    @ExplainError("Lambda는 호출됐으나 조회된 종목이 없습니다. 휴장일이거나 Lambda 내부 필터링 결과가 비어 있을 수 있습니다.")
+    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4451, "KRX 종목 조회 Lambda 응답이 비어있습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/api/krx/exception/KrxErrorStatus.java
+++ b/src/main/java/com/example/demo/api/krx/exception/KrxErrorStatus.java
@@ -15,9 +15,14 @@ import java.util.Objects;
 public enum KrxErrorStatus implements BaseErrorCode {
 
     // KRX 연동(4450~4499)
+    @ExplainError("Lambda 호출 자체가 실패했습니다. 네트워크·IAM 권한·스로틀링 등을 확인하세요.")
     KRX_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4450, "KRX 종목 조회 Lambda 호출에 실패했습니다."),
     @ExplainError("Lambda는 호출됐으나 조회된 종목이 없습니다. 휴장일이거나 Lambda 내부 필터링 결과가 비어 있을 수 있습니다.")
-    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4451, "KRX 종목 조회 Lambda 응답이 비어있습니다.");
+    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4451, "KRX 종목 조회 Lambda 응답이 비어있습니다."),
+    @ExplainError("Lambda는 호출됐으나 함수 내부에서 예외가 발생했습니다. Lambda 로그를 확인하세요.")
+    KRX_LAMBDA_EXECUTION_ERROR(HttpStatus.BAD_GATEWAY, 4452, "KRX 종목 조회 Lambda 실행 중 오류가 발생했습니다."),
+    @ExplainError("Lambda 응답 형식이 KrxOhlcvResponseDto와 맞지 않습니다. 양쪽 계약을 확인하세요.")
+    KRX_LAMBDA_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, 4453, "KRX 종목 조회 Lambda 응답을 해석하지 못했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/api/krx/exception/KrxHandler.java
+++ b/src/main/java/com/example/demo/api/krx/exception/KrxHandler.java
@@ -1,0 +1,19 @@
+package com.example.demo.api.krx.exception;
+
+import com.example.demo.common.exception.BaseErrorCode;
+import com.example.demo.common.exception.GeneralException;
+
+public class KrxHandler extends GeneralException {
+
+    public KrxHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+
+    public static KrxHandler krxLambdaInvokeError() {
+        return new KrxHandler(KrxErrorStatus.KRX_LAMBDA_INVOKE_ERROR);
+    }
+
+    public static KrxHandler krxLambdaResponseEmpty() {
+        return new KrxHandler(KrxErrorStatus.KRX_LAMBDA_RESPONSE_EMPTY);
+    }
+}

--- a/src/main/java/com/example/demo/api/krx/exception/KrxHandler.java
+++ b/src/main/java/com/example/demo/api/krx/exception/KrxHandler.java
@@ -16,4 +16,12 @@ public class KrxHandler extends GeneralException {
     public static KrxHandler krxLambdaResponseEmpty() {
         return new KrxHandler(KrxErrorStatus.KRX_LAMBDA_RESPONSE_EMPTY);
     }
+
+    public static KrxHandler krxLambdaExecutionError() {
+        return new KrxHandler(KrxErrorStatus.KRX_LAMBDA_EXECUTION_ERROR);
+    }
+
+    public static KrxHandler krxLambdaResponseParseError() {
+        return new KrxHandler(KrxErrorStatus.KRX_LAMBDA_RESPONSE_PARSE_ERROR);
+    }
 }

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -14,22 +14,27 @@ public class KrxService {
 
     private final KrxLambdaClient krxLambdaClient;
 
+    /**
+     * 호출 실패·실행 오류·응답 파싱 실패는 {@link KrxLambdaClient}가 각각의 도메인 예외로 변환해 던진다.
+     * 여기서는 "응답은 왔지만 종목이 비어 있는" 경우만 판정한다.
+     */
     public KrxOhlcvResponseDto getTopMarketCapOhlcv(int topN) {
-        try {
-            KrxOhlcvResponseDto response = krxLambdaClient.invokeGetTopMarketCapOhlcv(topN);
+        KrxOhlcvResponseDto response = krxLambdaClient.invokeGetTopMarketCapOhlcv(topN);
 
-            if (response == null || response.getStocks() == null || response.getStocks().isEmpty()) {
-                log.error("KRX Lambda 응답이 비어있습니다. topN={}", topN);
-                throw KrxHandler.krxLambdaResponseEmpty();
-            }
-
-            return response;
-
-        } catch (KrxHandler e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("KRX Lambda 호출 실패. topN={}", topN, e);
-            throw KrxHandler.krxLambdaInvokeError();
+        if (response == null || response.getStocks() == null || response.getStocks().isEmpty()) {
+            log.error("KRX Lambda 응답이 비어있습니다. topN={}", topN);
+            throw KrxHandler.krxLambdaResponseEmpty();
         }
+
+        // Lambda가 종목별로 실패를 격리하고 errors에 사유를 담아 보낸다. 조용히 누락되지 않도록 남긴다.
+        if (response.getErrors() != null && !response.getErrors().isEmpty()) {
+            log.warn("KRX Lambda가 {}건을 제외했습니다. 수신 {}건 / 요청 {}건. 사유={}",
+                    response.getErrors().size(), response.getStocks().size(), topN,
+                    response.getErrors().stream()
+                            .map(e -> e.getStockCode() + ":" + e.getReason())
+                            .toList());
+        }
+
+        return response;
     }
 }

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -2,7 +2,7 @@ package com.example.demo.api.krx.service;
 
 import com.example.demo.api.krx.client.KrxLambdaClient;
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
-import com.example.demo.domain.volatility.exception.VolatilityHandler;
+import com.example.demo.api.krx.exception.KrxHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,16 +20,16 @@ public class KrxService {
 
             if (response == null || response.getStocks() == null || response.getStocks().isEmpty()) {
                 log.error("KRX Lambda 응답이 비어있습니다. topN={}", topN);
-                throw VolatilityHandler.krxLambdaResponseEmpty();
+                throw KrxHandler.krxLambdaResponseEmpty();
             }
 
             return response;
 
-        } catch (VolatilityHandler e) {
+        } catch (KrxHandler e) {
             throw e;
         } catch (Exception e) {
             log.error("KRX Lambda 호출 실패. topN={}", topN, e);
-            throw VolatilityHandler.krxLambdaInvokeError();
+            throw KrxHandler.krxLambdaInvokeError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -18,7 +18,7 @@ public class KrxService {
         try {
             KrxOhlcvResponseDto response = krxLambdaClient.invokeGetTopMarketCapOhlcv(topN);
 
-            if (response == null || response.getStocks() == null) {
+            if (response == null || response.getStocks() == null || response.getStocks().isEmpty()) {
                 log.error("KRX Lambda 응답이 비어있습니다. topN={}", topN);
                 throw VolatilityHandler.krxLambdaResponseEmpty();
             }

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -1,0 +1,35 @@
+package com.example.demo.api.krx.service;
+
+import com.example.demo.api.krx.client.KrxLambdaClient;
+import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KrxService {
+
+    private final KrxLambdaClient krxLambdaClient;
+
+    public KrxOhlcvResponseDto getTopMarketCapOhlcv(int topN) {
+        try {
+            KrxOhlcvResponseDto response = krxLambdaClient.invokeGetTopMarketCapOhlcv(topN);
+
+            if (response == null || response.getStocks() == null) {
+                log.error("KRX Lambda 응답이 비어있습니다. topN={}", topN);
+                throw VolatilityHandler.krxLambdaResponseEmpty();
+            }
+
+            return response;
+
+        } catch (VolatilityHandler e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("KRX Lambda 호출 실패. topN={}", topN, e);
+            throw VolatilityHandler.krxLambdaInvokeError();
+        }
+    }
+}

--- a/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
+++ b/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
@@ -1,6 +1,7 @@
 package com.example.demo.api.report.client;
 
 import com.example.demo.api.report.dto.ReportLambdaRequestDto;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -29,18 +30,25 @@ public class ReportLambdaClient {
             payload = objectMapper.writeValueAsString(request);
             log.info("[ReportLambda] payload: {}", payload);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("리포트 Lambda 요청 페이로드 생성 실패", e);
+            log.error("리포트 Lambda 요청 페이로드 생성 실패. stockCode={}", request.getStockCode(), e);
+            throw VolatilityHandler.reportLambdaInvokeError();
         }
 
-        InvokeResponse response = lambdaClient.invoke(InvokeRequest.builder()
-                .functionName(functionName)
-                .payload(SdkBytes.fromUtf8String(payload))
-                .build());
+        InvokeResponse response;
+        try {
+            response = lambdaClient.invoke(InvokeRequest.builder()
+                    .functionName(functionName)
+                    .payload(SdkBytes.fromUtf8String(payload))
+                    .build());
+        } catch (Exception e) {
+            log.error("리포트 Lambda 호출 실패. stockCode={}", request.getStockCode(), e);
+            throw VolatilityHandler.reportLambdaInvokeError();
+        }
 
         if (response.functionError() != null) {
-            throw new IllegalStateException(
-                    "리포트 Lambda 실행 오류: " + response.functionError()
-                            + ", payload=" + response.payload().asUtf8String());
+            log.error("리포트 Lambda 실행 오류. stockCode={}, functionError={}, payload={}",
+                    request.getStockCode(), response.functionError(), response.payload().asUtf8String());
+            throw VolatilityHandler.reportLambdaInvokeError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
+++ b/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
@@ -1,0 +1,46 @@
+package com.example.demo.api.report.client;
+
+import com.example.demo.api.report.dto.ReportLambdaRequestDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportLambdaClient {
+
+    private final LambdaClient lambdaClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${report.lambda.function-name}")
+    private String functionName;
+
+    public void invokeCreateReport(ReportLambdaRequestDto request) {
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(request);
+            log.info("[ReportLambda] payload: {}", payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("리포트 Lambda 요청 페이로드 생성 실패", e);
+        }
+
+        InvokeResponse response = lambdaClient.invoke(InvokeRequest.builder()
+                .functionName(functionName)
+                .payload(SdkBytes.fromUtf8String(payload))
+                .build());
+
+        if (response.functionError() != null) {
+            throw new IllegalStateException(
+                    "리포트 Lambda 실행 오류: " + response.functionError()
+                            + ", payload=" + response.payload().asUtf8String());
+        }
+    }
+}

--- a/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
+++ b/src/main/java/com/example/demo/api/report/client/ReportLambdaClient.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -30,8 +31,8 @@ public class ReportLambdaClient {
             payload = objectMapper.writeValueAsString(request);
             log.info("[ReportLambda] payload: {}", payload);
         } catch (JsonProcessingException e) {
-            log.error("리포트 Lambda 요청 페이로드 생성 실패. stockCode={}", request.getStockCode(), e);
-            throw VolatilityHandler.reportLambdaInvokeError();
+            // DTO 직렬화 실패는 우리 코드 버그이므로 500으로 내보낸다.
+            throw new IllegalStateException("리포트 Lambda 요청 페이로드 생성 실패", e);
         }
 
         InvokeResponse response;
@@ -40,15 +41,16 @@ public class ReportLambdaClient {
                     .functionName(functionName)
                     .payload(SdkBytes.fromUtf8String(payload))
                     .build());
-        } catch (Exception e) {
-            log.error("리포트 Lambda 호출 실패. stockCode={}", request.getStockCode(), e);
+        } catch (SdkException e) {
+            log.error("리포트 Lambda 호출 실패. functionName={}, stockCode={}",
+                    functionName, request.getStockCode(), e);
             throw VolatilityHandler.reportLambdaInvokeError();
         }
 
         if (response.functionError() != null) {
             log.error("리포트 Lambda 실행 오류. stockCode={}, functionError={}, payload={}",
                     request.getStockCode(), response.functionError(), response.payload().asUtf8String());
-            throw VolatilityHandler.reportLambdaInvokeError();
+            throw VolatilityHandler.reportLambdaExecutionError();
         }
     }
 }

--- a/src/main/java/com/example/demo/api/report/dto/ReportLambdaRequestDto.java
+++ b/src/main/java/com/example/demo/api/report/dto/ReportLambdaRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.api.report.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReportLambdaRequestDto {
+    private String jobId;
+    private String stockCode;
+    private String stockName;
+    private String reportDate;
+    private String triggerType;
+    private String gptModel;
+}

--- a/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
+++ b/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
@@ -1,6 +1,7 @@
 package com.example.demo.api.stock.service;
 
 import com.example.demo.api.kis.dto.KisResponseDto;
+import com.example.demo.api.kis.exception.KisHandler;
 import com.example.demo.api.kis.service.KisService;
 import com.example.demo.api.stock.dto.StockResponseDto.*;
 import com.example.demo.api.stock.dto.StockSyncResultDto;
@@ -107,7 +108,7 @@ public class StockUseCase {
             }
         }
 
-        throw StockHandler.stockPriceResponseEmpty();
+        throw KisHandler.kisResponseEmpty();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
+++ b/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
@@ -74,11 +74,8 @@ public class StockUseCase {
 
     @Transactional
     public StockPriceResponse getLatestStockPriceByStockCode(String stockCode) {
-        Stock stock = stockQueryService.getStockByCode(stockCode);
-
-        if (stock == null) {
-            throw StockHandler.notFound();
-        }
+        // 존재하지 않는 종목이면 getStockByCode가 StockHandler.notFound()를 던진다.
+        stockQueryService.getStockByCode(stockCode);
 
         for (int i = 1; i <= 10; i++) {
             LocalDate targetDate = LocalDate.now(SEOUL_ZONE).minusDays(i);

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -17,8 +17,15 @@ import java.time.LocalDate;
 public class VolatilityController {
     private final VolatilityUseCase volatilityUseCase;
 
-    @Operation(summary = "특정 날짜의 변동성 종목 전체 조회", description = "특정 날짜에 생성된 변동성 종목 전체를 조회합니다.")
-    @GetMapping
+    @Operation(summary = "변동성 탐지 실행", description = "KRX Lambda에서 OHLCV를 조회하고 변동성을 계산하여 변동성이 탐지된 종목 결과를 저장합니다.")
+    @PostMapping("/detect")
+    public ApiResponseDto<Void> runDetection() {
+        volatilityUseCase.runDetection();
+        return ApiResponseDto.onSuccess(null);
+    }
+
+    @Operation(summary = "특정 날짜의 변동성 종목 전체 조회", description = "특정 날짜에 생성된 변동성 종목 전체를 조회합니다. 날짜 입력 형식은 \"yyyy-mm-dd\"입니다.")
+    @GetMapping("/volatilty-by-date")
     public ApiResponseDto<VolatilityListResponse> getAllVolatilityByDate(@RequestParam LocalDate date) {
         return ApiResponseDto.onSuccess(volatilityUseCase.getAllVolatilityByDate(date));
     }

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -31,7 +31,7 @@ public class VolatilityController {
         return ApiResponseDto.onSuccess(volatilityUseCase.runDetection());
     }
 
-    @Operation(summary = "변동성 리포트 생성 요청", description = "오늘 탐지된 변동성 종목에 대한 리포트 생성을 Lambda에 요청합니다.<br>" +
+    @Operation(summary = "변동성 리포트 생성 요청", description = "오늘 탐지된 변동성 종목에 대한 리포트 생성을 Lambda에 요청합니다. 기본값으로 하고 싶으면 gptModel을 지우시면 됩니다.<br>" +
             "모델 목록: gpt-5.6-sol, gpt-5.6-terra(기본값), gpt-5.6-luna, gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro")
     @PostMapping(value = "/report", consumes = APPLICATION_JSON_VALUE)
     public ApiResponseDto<ReportGenerationResult> runReportGeneration(@RequestBody ReportGenerationRequest request) {

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -56,8 +56,10 @@ public class VolatilityController {
         return ApiResponseDto.onSuccess(null);
     }
 
-    @Operation(summary = "리포트 생성 완료 콜백", description = "ECS가 리포트 생성 완료 후 reportUrl을 전달합니다." +
-            "테스트에서는 이 api를 실행해야 S3에 생성 및 저장된 리포트가 DB에 저장됩니다.<br>" + "형식은 종목 코드, 생성 일자(파일명의 일자, yyyymmdd), S3 URL입니다.")
+    @Operation(summary = "리포트 생성 완료 콜백", description = "ECS가 리포트 생성 완료 후 reportUrl을 전달합니다. " +
+            "테스트에서는 이 api를 실행해야 S3에 생성 및 저장된 리포트가 DB에 저장됩니다.<br>" +
+            "형식은 종목 코드, 생성 일자(파일명의 일자, yyyymmdd), S3 URL입니다.<br>" +
+            "callback-secret은 문서의 REPORT_CALLBACK_SECRET 환경 변수 넣어주면 됩니다.")
     @PatchMapping(value = "/report/callback", consumes = APPLICATION_JSON_VALUE)
     public ApiResponseDto<Void> reportCallback(
             @RequestHeader(value = CALLBACK_SECRET_HEADER, required = false) String secret,

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -1,12 +1,20 @@
 package com.example.demo.api.volatility.controller;
 
 import com.example.demo.api.common.dto.ApiResponseDto;
+import com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportCallback;
+import com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
+import com.example.demo.api.volatility.dto.VolatilityRequestDto.SingleReportRequest;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.DetectionResult;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGenerationResult;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.api.volatility.service.VolatilityUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.time.LocalDate;
 
@@ -19,8 +27,30 @@ public class VolatilityController {
 
     @Operation(summary = "변동성 탐지 실행", description = "KRX Lambda에서 OHLCV를 조회하고 변동성을 계산하여 변동성이 탐지된 종목 결과를 저장합니다.")
     @PostMapping("/detect")
-    public ApiResponseDto<Void> runDetection() {
-        volatilityUseCase.runDetection();
+    public ApiResponseDto<DetectionResult> runDetection() {
+        return ApiResponseDto.onSuccess(volatilityUseCase.runDetection());
+    }
+
+    @Operation(summary = "변동성 리포트 생성 요청", description = "오늘 탐지된 변동성 종목에 대한 리포트 생성을 Lambda에 요청합니다.<br>" +
+            "모델 목록: gpt-5.6-sol, gpt-5.6-terra(기본값), gpt-5.6-luna, gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro")
+    @PostMapping(value = "/report", consumes = APPLICATION_JSON_VALUE)
+    public ApiResponseDto<ReportGenerationResult> runReportGeneration(@RequestBody ReportGenerationRequest request) {
+        return ApiResponseDto.onSuccess(volatilityUseCase.runReportGeneration(request));
+    }
+
+    @Operation(summary = "[테스트] 단일 종목 리포트 생성 요청", description = "테스트용. 종목 코드와 이름을 직접 입력해 Lambda에 리포트 생성을 요청합니다.<br>" +
+            "모델 목록: gpt-5.6-sol, gpt-5.6-terra(기본값), gpt-5.6-luna, gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro")
+    @PostMapping(value = "/report/test", consumes = APPLICATION_JSON_VALUE)
+    public ApiResponseDto<Void> runSingleReportGeneration(@RequestBody @Valid SingleReportRequest request) {
+        volatilityUseCase.runSingleReportGeneration(request);
+        return ApiResponseDto.onSuccess(null);
+    }
+
+    @Operation(summary = "리포트 생성 완료 콜백", description = "ECS가 리포트 생성 완료 후 reportUrl을 전달합니다." +
+            "테스트에서는 이 api를 실행해야 S3에 생성 및 저장된 리포트가 DB에 저장됩니다.<br>" + "형식은 종목 코드, 생성 일자(파일명의 일자, yyyymmdd), S3 URL입니다.")
+    @PatchMapping(value = "/report/callback", consumes = APPLICATION_JSON_VALUE)
+    public ApiResponseDto<Void> reportCallback(@RequestBody ReportCallback request) {
+        volatilityUseCase.handleReportCallback(request);
         return ApiResponseDto.onSuccess(null);
     }
 

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -8,14 +8,18 @@ import com.example.demo.api.volatility.dto.VolatilityResponseDto.DetectionResult
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGenerationResult;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.api.volatility.service.VolatilityUseCase;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.LocalDate;
 
 @Tag(name = "[변동성 종목 페이지] 변동성 종목 API")
@@ -23,7 +27,13 @@ import java.time.LocalDate;
 @RequestMapping("/api/v1/volatility")
 @RequiredArgsConstructor
 public class VolatilityController {
+
+    private static final String CALLBACK_SECRET_HEADER = "X-Callback-Secret";
+
     private final VolatilityUseCase volatilityUseCase;
+
+    @Value("${report.callback.secret}")
+    private String callbackSecret;
 
     @Operation(summary = "변동성 탐지 실행", description = "KRX Lambda에서 OHLCV를 조회하고 변동성을 계산하여 변동성이 탐지된 종목 결과를 저장합니다.")
     @PostMapping("/detect")
@@ -49,9 +59,21 @@ public class VolatilityController {
     @Operation(summary = "리포트 생성 완료 콜백", description = "ECS가 리포트 생성 완료 후 reportUrl을 전달합니다." +
             "테스트에서는 이 api를 실행해야 S3에 생성 및 저장된 리포트가 DB에 저장됩니다.<br>" + "형식은 종목 코드, 생성 일자(파일명의 일자, yyyymmdd), S3 URL입니다.")
     @PatchMapping(value = "/report/callback", consumes = APPLICATION_JSON_VALUE)
-    public ApiResponseDto<Void> reportCallback(@RequestBody @Valid ReportCallback request) {
+    public ApiResponseDto<Void> reportCallback(
+            @RequestHeader(value = CALLBACK_SECRET_HEADER, required = false) String secret,
+            @RequestBody @Valid ReportCallback request) {
+        verifyCallbackSecret(secret);
         volatilityUseCase.handleReportCallback(request);
         return ApiResponseDto.onSuccess(null);
+    }
+
+    /** 콜백은 JWT 없이 열려 있으므로 공유 시크릿으로 검증한다. 타이밍 공격을 피해 상수 시간 비교를 쓴다. */
+    private void verifyCallbackSecret(String secret) {
+        if (secret == null || !MessageDigest.isEqual(
+                secret.getBytes(StandardCharsets.UTF_8),
+                callbackSecret.getBytes(StandardCharsets.UTF_8))) {
+            throw VolatilityHandler.reportCallbackUnauthorized();
+        }
     }
 
     @Operation(summary = "특정 날짜의 변동성 종목 전체 조회", description = "특정 날짜에 생성된 변동성 종목 전체를 조회합니다. 날짜 입력 형식은 \"yyyy-mm-dd\"입니다.")

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -55,7 +55,7 @@ public class VolatilityController {
     }
 
     @Operation(summary = "특정 날짜의 변동성 종목 전체 조회", description = "특정 날짜에 생성된 변동성 종목 전체를 조회합니다. 날짜 입력 형식은 \"yyyy-mm-dd\"입니다.")
-    @GetMapping("/volatilty-by-date")
+    @GetMapping("/volatility-by-date")
     public ApiResponseDto<VolatilityListResponse> getAllVolatilityByDate(@RequestParam LocalDate date) {
         return ApiResponseDto.onSuccess(volatilityUseCase.getAllVolatilityByDate(date));
     }

--- a/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
+++ b/src/main/java/com/example/demo/api/volatility/controller/VolatilityController.java
@@ -49,7 +49,7 @@ public class VolatilityController {
     @Operation(summary = "리포트 생성 완료 콜백", description = "ECS가 리포트 생성 완료 후 reportUrl을 전달합니다." +
             "테스트에서는 이 api를 실행해야 S3에 생성 및 저장된 리포트가 DB에 저장됩니다.<br>" + "형식은 종목 코드, 생성 일자(파일명의 일자, yyyymmdd), S3 URL입니다.")
     @PatchMapping(value = "/report/callback", consumes = APPLICATION_JSON_VALUE)
-    public ApiResponseDto<Void> reportCallback(@RequestBody ReportCallback request) {
+    public ApiResponseDto<Void> reportCallback(@RequestBody @Valid ReportCallback request) {
         volatilityUseCase.handleReportCallback(request);
         return ApiResponseDto.onSuccess(null);
     }

--- a/src/main/java/com/example/demo/api/volatility/dto/VolatilityRequestDto.java
+++ b/src/main/java/com/example/demo/api/volatility/dto/VolatilityRequestDto.java
@@ -1,6 +1,9 @@
 package com.example.demo.api.volatility.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,24 +12,45 @@ public class VolatilityRequestDto {
     @Getter
     @NoArgsConstructor
     public static class ReportGenerationRequest {
+        @Schema(description = "사용할 GPT 모델. 비우면 Lambda 기본값을 사용합니다.", example = "gpt-5.6-terra")
         private String gptModel;
     }
 
+    /** 외부(Lambda)에서 들어오는 요청이므로 모든 필드를 검증한다. */
     @Getter
     @NoArgsConstructor
     public static class ReportCallback {
+        @Schema(description = "종목 코드(숫자 6자리)", example = "005930")
+        @NotBlank(message = "종목 코드는 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "종목 코드는 숫자 6자리여야 합니다.")
         private String stockCode;
-        private String reportDate; // "yyyyMMdd"
+
+        @Schema(description = "리포트 생성일(S3 파일명의 날짜, yyyyMMdd)", example = "20260802")
+        @NotBlank(message = "리포트 생성일은 필수입니다.")
+        @Pattern(regexp = "\\d{8}", message = "리포트 생성일은 yyyyMMdd 형식이어야 합니다.")
+        private String reportDate;
+
+        @Schema(description = "S3에 저장된 리포트 URL",
+                example = "https://treat-finance-reports.s3.ap-northeast-2.amazonaws.com/005930_삼성전자_20260802_analysis.html")
+        @NotBlank(message = "리포트 URL은 필수입니다.")
+        @Size(max = 2048, message = "리포트 URL이 너무 깁니다.")
+        @Pattern(regexp = "https://.+", message = "리포트 URL은 https로 시작해야 합니다.")
         private String reportUrl;
     }
 
     @Getter
     @NoArgsConstructor
     public static class SingleReportRequest {
-        @NotBlank
+        @Schema(description = "종목 코드(숫자 6자리)", example = "005930")
+        @NotBlank(message = "종목 코드는 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "종목 코드는 숫자 6자리여야 합니다.")
         private String stockCode;
-        @NotBlank
+
+        @Schema(description = "종목 이름", example = "삼성전자")
+        @NotBlank(message = "종목 이름은 필수입니다.")
         private String stockName;
+
+        @Schema(description = "사용할 GPT 모델. 비우면 Lambda 기본값을 사용합니다.", example = "gpt-5.6-terra")
         private String gptModel;
     }
 }

--- a/src/main/java/com/example/demo/api/volatility/dto/VolatilityRequestDto.java
+++ b/src/main/java/com/example/demo/api/volatility/dto/VolatilityRequestDto.java
@@ -1,0 +1,32 @@
+package com.example.demo.api.volatility.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class VolatilityRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class ReportGenerationRequest {
+        private String gptModel;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ReportCallback {
+        private String stockCode;
+        private String reportDate; // "yyyyMMdd"
+        private String reportUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SingleReportRequest {
+        @NotBlank
+        private String stockCode;
+        @NotBlank
+        private String stockName;
+        private String gptModel;
+    }
+}

--- a/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
+++ b/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
@@ -33,8 +33,13 @@ public class VolatilityResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ReportGenerationResult {
+        /** SUCCESS(전부 성공) / PARTIAL_SUCCESS(일부 실패) / FAILURE(전부 실패) */
         private String status;
         private int requestedCount;
+        private int successCount;
+        private int failedCount;
+        /** 요청에 실패해 리포트가 생성되지 않는 종목 코드. */
+        private List<String> failedStockCodes;
     }
 
     @Getter

--- a/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
+++ b/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
@@ -14,6 +14,33 @@ public class VolatilityResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class DetectedStock {
+        private String stockCode;
+        private String stockName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetectionResult {
+        private List<DetectedStock> stocks;
+        private int detectedCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportGenerationResult {
+        private String status;
+        private int requestedCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class VolatilityInfo {
         private String stockCode;
         private String stockName;

--- a/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
+++ b/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
@@ -6,7 +6,7 @@ import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGeneratio
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityInfo;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.domain.volatility.entity.Volatility;
-import com.example.demo.domain.volatility.service.VolatilitySignal;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
+++ b/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
@@ -11,6 +11,8 @@ import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.example.demo.common.consts.StaticVariable.*;
+
 public class VolatilityConverter {
 
     public static DetectionResult toDetectionResult(List<VolatilitySignal> signals) {
@@ -30,11 +32,11 @@ public class VolatilityConverter {
         int failedCount = failedStockCodes.size();
         String status;
         if (failedCount == 0) {
-            status = "SUCCESS";
+            status = REPORT_GENERATION_SUCCESS;
         } else if (failedCount == requestedCount) {
-            status = "FAILURE";
+            status = REPORT_GENERATION_FAILURE;
         } else {
-            status = "PARTIAL_SUCCESS";
+            status = REPORT_GENERATION_PARTIAL_SUCCESS;
         }
 
         return ReportGenerationResult.builder()

--- a/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
+++ b/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
@@ -26,10 +26,23 @@ public class VolatilityConverter {
                 .build();
     }
 
-    public static ReportGenerationResult toReportGenerationResult(int requestedCount, boolean success) {
+    public static ReportGenerationResult toReportGenerationResult(int requestedCount, List<String> failedStockCodes) {
+        int failedCount = failedStockCodes.size();
+        String status;
+        if (failedCount == 0) {
+            status = "SUCCESS";
+        } else if (failedCount == requestedCount) {
+            status = "FAILURE";
+        } else {
+            status = "PARTIAL_SUCCESS";
+        }
+
         return ReportGenerationResult.builder()
-                .status(success ? "SUCCESS" : "FAILURE")
+                .status(status)
                 .requestedCount(requestedCount)
+                .successCount(requestedCount - failedCount)
+                .failedCount(failedCount)
+                .failedStockCodes(failedStockCodes)
                 .build();
     }
 

--- a/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
+++ b/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
@@ -1,13 +1,37 @@
 package com.example.demo.api.volatility.mapper;
 
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.DetectedStock;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.DetectionResult;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGenerationResult;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityInfo;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.service.VolatilitySignal;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class VolatilityConverter {
+
+    public static DetectionResult toDetectionResult(List<VolatilitySignal> signals) {
+        List<DetectedStock> stocks = signals.stream()
+                .map(s -> DetectedStock.builder()
+                        .stockCode(s.stockCode())
+                        .stockName(s.stockName())
+                        .build())
+                .collect(Collectors.toList());
+        return DetectionResult.builder()
+                .stocks(stocks)
+                .detectedCount(stocks.size())
+                .build();
+    }
+
+    public static ReportGenerationResult toReportGenerationResult(int requestedCount, boolean success) {
+        return ReportGenerationResult.builder()
+                .status(success ? "SUCCESS" : "FAILURE")
+                .requestedCount(requestedCount)
+                .build();
+    }
 
     public static VolatilityInfo toVolatilityInfo(Volatility volatility) {
         return VolatilityInfo.builder()

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -7,7 +7,6 @@ import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGeneratio
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.api.volatility.mapper.VolatilityConverter;
 import com.example.demo.common.annotation.UseCase;
-import com.example.demo.common.service.RedisService;
 import com.example.demo.domain.volatility.entity.Volatility;
 import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
@@ -39,7 +38,6 @@ public class VolatilityUseCase {
     private final VolatilityDetectionService volatilityDetectionService;
     private final VolatilityCommandService volatilityCommandService;
     private final ReportLambdaClient reportLambdaClient;
-    private final RedisService redisService;
 
     private static final DateTimeFormatter REPORT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
@@ -80,20 +78,14 @@ public class VolatilityUseCase {
 
     private void invokeReportJob(String reportDate, String stockCode, String stockName, String gptModel) {
         String jobId = "VOLATILITY_" + reportDate + "_" + stockCode;
-        redisService.setVolatilityReportJob(reportDate, stockCode, "PENDING");
-        try {
-            reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
-                    .jobId(jobId)
-                    .stockCode(stockCode)
-                    .stockName(stockName)
-                    .reportDate(reportDate)
-                    .triggerType("VOLATILITY")
-                    .gptModel(gptModel)
-                    .build());
-        } catch (Exception e) {
-            redisService.setVolatilityReportJob(reportDate, stockCode, "FAILED");
-            throw e;
-        }
+        reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
+                .jobId(jobId)
+                .stockCode(stockCode)
+                .stockName(stockName)
+                .reportDate(reportDate)
+                .triggerType("VOLATILITY")
+                .gptModel(gptModel)
+                .build());
     }
 
     public void handleReportCallback(ReportCallback request) {
@@ -104,7 +96,6 @@ public class VolatilityUseCase {
             throw VolatilityHandler.reportCallbackInvalidRequest();
         }
         volatilityCommandService.updateReportUrl(request.getStockCode(), reportDate, request.getReportUrl());
-        redisService.setVolatilityReportJob(request.getReportDate(), request.getStockCode(), "COMPLETED");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -3,18 +3,30 @@ package com.example.demo.api.volatility.service;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.api.volatility.mapper.VolatilityConverter;
 import com.example.demo.common.annotation.UseCase;
+import com.example.demo.domain.volatility.service.VolatilityCommandService;
+import com.example.demo.domain.volatility.service.VolatilityDetectionService;
 import com.example.demo.domain.volatility.service.VolatilityQueryService;
+import com.example.demo.domain.volatility.service.VolatilitySignal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @UseCase
 @Transactional
 @RequiredArgsConstructor
 public class VolatilityUseCase {
     private final VolatilityQueryService volatilityQueryService;
+    private final VolatilityDetectionService volatilityDetectionService;
+    private final VolatilityCommandService volatilityCommandService;
+
+    public void runDetection() {
+        List<VolatilitySignal> signals = volatilityDetectionService.detect(100);
+        List<VolatilitySignal> top10 = volatilityDetectionService.selectTop(signals, 100, 10);
+        volatilityCommandService.saveTopVolatilityStocks(top10);
+    }
 
     @Transactional(readOnly = true)
     public VolatilityListResponse getAllVolatilityByDate(LocalDate date) {

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -1,8 +1,14 @@
 package com.example.demo.api.volatility.service;
 
+import com.example.demo.api.report.client.ReportLambdaClient;
+import com.example.demo.api.report.dto.ReportLambdaRequestDto;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.DetectionResult;
+import com.example.demo.api.volatility.dto.VolatilityResponseDto.ReportGenerationResult;
 import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListResponse;
 import com.example.demo.api.volatility.mapper.VolatilityConverter;
 import com.example.demo.common.annotation.UseCase;
+import com.example.demo.common.service.RedisService;
+import com.example.demo.domain.volatility.entity.Volatility;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
 import com.example.demo.domain.volatility.service.VolatilityDetectionService;
 import com.example.demo.domain.volatility.service.VolatilityQueryService;
@@ -12,7 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportCallback;
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.SingleReportRequest;
 
 @UseCase
 @Transactional
@@ -21,11 +32,59 @@ public class VolatilityUseCase {
     private final VolatilityQueryService volatilityQueryService;
     private final VolatilityDetectionService volatilityDetectionService;
     private final VolatilityCommandService volatilityCommandService;
+    private final ReportLambdaClient reportLambdaClient;
+    private final RedisService redisService;
 
-    public void runDetection() {
+    private static final DateTimeFormatter REPORT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public DetectionResult runDetection() {
         List<VolatilitySignal> signals = volatilityDetectionService.detect(100);
         List<VolatilitySignal> top10 = volatilityDetectionService.selectTop(signals, 100, 10);
         volatilityCommandService.saveTopVolatilityStocks(top10);
+        return VolatilityConverter.toDetectionResult(top10);
+    }
+
+    public ReportGenerationResult runReportGeneration(ReportGenerationRequest request) {
+        List<Volatility> todayVolatility = volatilityQueryService.getTodayVolatility();
+        if (todayVolatility.isEmpty()) {
+            throw new IllegalStateException("오늘 탐지된 변동성 종목이 없습니다. 먼저 /detect를 실행하세요.");
+        }
+
+        String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
+        redisService.setVolatilityReportJob(reportDate, "PENDING");
+
+        for (Volatility v : todayVolatility) {
+            String jobId = "VOLATILITY_" + reportDate + "_" + v.getStockCode();
+            reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
+                    .jobId(jobId)
+                    .stockCode(v.getStockCode())
+                    .stockName(v.getStockName())
+                    .reportDate(reportDate)
+                    .triggerType("VOLATILITY")
+                    .gptModel(request.getGptModel())
+                    .build());
+        }
+
+        return VolatilityConverter.toReportGenerationResult(todayVolatility.size(), true);
+    }
+
+    public void runSingleReportGeneration(SingleReportRequest request) {
+        String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
+        String jobId = "VOLATILITY_" + reportDate + "_" + request.getStockCode();
+        reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
+                .jobId(jobId)
+                .stockCode(request.getStockCode())
+                .stockName(request.getStockName())
+                .reportDate(reportDate)
+                .triggerType("VOLATILITY")
+                .gptModel(request.getGptModel())
+                .build());
+    }
+
+    public void handleReportCallback(ReportCallback request) {
+        LocalDate reportDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
+        volatilityCommandService.updateReportUrl(request.getStockCode(), reportDate, request.getReportUrl());
+        redisService.setVolatilityReportJob(request.getReportDate(), "COMPLETED");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -56,14 +56,19 @@ public class VolatilityUseCase {
         for (Volatility v : todayVolatility) {
             String jobId = "VOLATILITY_" + reportDate + "_" + v.getStockCode();
             redisService.setVolatilityReportJob(reportDate, v.getStockCode(), "PENDING");
-            reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
-                    .jobId(jobId)
-                    .stockCode(v.getStockCode())
-                    .stockName(v.getStockName())
-                    .reportDate(reportDate)
-                    .triggerType("VOLATILITY")
-                    .gptModel(request.getGptModel())
-                    .build());
+            try {
+                reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
+                        .jobId(jobId)
+                        .stockCode(v.getStockCode())
+                        .stockName(v.getStockName())
+                        .reportDate(reportDate)
+                        .triggerType("VOLATILITY")
+                        .gptModel(request.getGptModel())
+                        .build());
+            } catch (Exception e) {
+                redisService.setVolatilityReportJob(reportDate, v.getStockCode(), "FAILED");
+                throw e;
+            }
         }
 
         return VolatilityConverter.toReportGenerationResult(todayVolatility.size(), true);
@@ -73,14 +78,19 @@ public class VolatilityUseCase {
         String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
         String jobId = "VOLATILITY_" + reportDate + "_" + request.getStockCode();
         redisService.setVolatilityReportJob(reportDate, request.getStockCode(), "PENDING");
-        reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
-                .jobId(jobId)
-                .stockCode(request.getStockCode())
-                .stockName(request.getStockName())
-                .reportDate(reportDate)
-                .triggerType("VOLATILITY")
-                .gptModel(request.getGptModel())
-                .build());
+        try {
+            reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
+                    .jobId(jobId)
+                    .stockCode(request.getStockCode())
+                    .stockName(request.getStockName())
+                    .reportDate(reportDate)
+                    .triggerType("VOLATILITY")
+                    .gptModel(request.getGptModel())
+                    .build());
+        } catch (Exception e) {
+            redisService.setVolatilityReportJob(reportDate, request.getStockCode(), "FAILED");
+            throw e;
+        }
     }
 
     public void handleReportCallback(ReportCallback request) {

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -43,7 +43,20 @@ public class VolatilityUseCase {
 
     public DetectionResult runDetection() {
         List<VolatilitySignal> signals = volatilityDetectionService.detect(100);
+
+        // 전 종목이 스킵된 경우다. 저장(오늘 기록 삭제 후 재삽입)으로 넘어가면
+        // 기존 데이터만 지우고 끝나므로, 반드시 저장 전에 중단한다.
+        if (signals.isEmpty()) {
+            log.error("변동성 분석 결과가 비어 있습니다. 전 종목이 스킵됐습니다.");
+            throw VolatilityHandler.volatilityDetectionFailed();
+        }
+
         List<VolatilitySignal> top10 = volatilityDetectionService.selectTop(signals, 100, 10);
+        if (top10.isEmpty()) {
+            // 분석은 정상이나 알림 조건을 만족한 종목이 없는 날. 오늘 기록은 비워진다.
+            log.warn("변동성 알림이 탐지된 종목이 없습니다. 분석 종목 수={}", signals.size());
+        }
+
         volatilityCommandService.saveTopVolatilityStocks(top10);
         return VolatilityConverter.toDetectionResult(top10);
     }

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -9,23 +9,28 @@ import com.example.demo.api.volatility.mapper.VolatilityConverter;
 import com.example.demo.common.annotation.UseCase;
 import com.example.demo.common.service.RedisService;
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
 import com.example.demo.domain.volatility.service.VolatilityDetectionService;
 import com.example.demo.domain.volatility.service.VolatilityQueryService;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportCallback;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.SingleReportRequest;
 
+@Slf4j
 @UseCase
 @Transactional
 @RequiredArgsConstructor
@@ -49,52 +54,55 @@ public class VolatilityUseCase {
     public ReportGenerationResult runReportGeneration(ReportGenerationRequest request) {
         List<Volatility> todayVolatility = volatilityQueryService.getTodayVolatility();
         if (todayVolatility.isEmpty()) {
-            throw new IllegalStateException("오늘 탐지된 변동성 종목이 없습니다. 먼저 /detect를 실행하세요.");
+            throw VolatilityHandler.volatilityNotDetectedToday();
         }
 
         String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
+
+        // 한 종목이 실패해도 나머지 종목의 리포트 생성은 계속 요청한다.
+        List<String> failedStockCodes = new ArrayList<>();
         for (Volatility v : todayVolatility) {
-            String jobId = "VOLATILITY_" + reportDate + "_" + v.getStockCode();
-            redisService.setVolatilityReportJob(reportDate, v.getStockCode(), "PENDING");
             try {
-                reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
-                        .jobId(jobId)
-                        .stockCode(v.getStockCode())
-                        .stockName(v.getStockName())
-                        .reportDate(reportDate)
-                        .triggerType("VOLATILITY")
-                        .gptModel(request.getGptModel())
-                        .build());
+                invokeReportJob(reportDate, v.getStockCode(), v.getStockName(), request.getGptModel());
             } catch (Exception e) {
-                redisService.setVolatilityReportJob(reportDate, v.getStockCode(), "FAILED");
-                throw e;
+                log.error("리포트 생성 요청 실패, 다음 종목으로 진행. stockCode={}", v.getStockCode(), e);
+                failedStockCodes.add(v.getStockCode());
             }
         }
 
-        return VolatilityConverter.toReportGenerationResult(todayVolatility.size(), true);
+        return VolatilityConverter.toReportGenerationResult(todayVolatility.size(), failedStockCodes);
     }
 
     public void runSingleReportGeneration(SingleReportRequest request) {
         String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
-        String jobId = "VOLATILITY_" + reportDate + "_" + request.getStockCode();
-        redisService.setVolatilityReportJob(reportDate, request.getStockCode(), "PENDING");
+        invokeReportJob(reportDate, request.getStockCode(), request.getStockName(), request.getGptModel());
+    }
+
+    private void invokeReportJob(String reportDate, String stockCode, String stockName, String gptModel) {
+        String jobId = "VOLATILITY_" + reportDate + "_" + stockCode;
+        redisService.setVolatilityReportJob(reportDate, stockCode, "PENDING");
         try {
             reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
                     .jobId(jobId)
-                    .stockCode(request.getStockCode())
-                    .stockName(request.getStockName())
+                    .stockCode(stockCode)
+                    .stockName(stockName)
                     .reportDate(reportDate)
                     .triggerType("VOLATILITY")
-                    .gptModel(request.getGptModel())
+                    .gptModel(gptModel)
                     .build());
         } catch (Exception e) {
-            redisService.setVolatilityReportJob(reportDate, request.getStockCode(), "FAILED");
+            redisService.setVolatilityReportJob(reportDate, stockCode, "FAILED");
             throw e;
         }
     }
 
     public void handleReportCallback(ReportCallback request) {
-        LocalDate reportDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
+        LocalDate reportDate;
+        try {
+            reportDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw VolatilityHandler.reportCallbackInvalidRequest();
+        }
         volatilityCommandService.updateReportUrl(request.getStockCode(), reportDate, request.getReportUrl());
         redisService.setVolatilityReportJob(request.getReportDate(), request.getStockCode(), "COMPLETED");
     }

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -12,8 +12,9 @@ import com.example.demo.domain.volatility.entity.Volatility;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
 import com.example.demo.domain.volatility.service.VolatilityDetectionService;
 import com.example.demo.domain.volatility.service.VolatilityQueryService;
-import com.example.demo.domain.volatility.service.VolatilitySignal;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -44,6 +45,7 @@ public class VolatilityUseCase {
         return VolatilityConverter.toDetectionResult(top10);
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public ReportGenerationResult runReportGeneration(ReportGenerationRequest request) {
         List<Volatility> todayVolatility = volatilityQueryService.getTodayVolatility();
         if (todayVolatility.isEmpty()) {
@@ -51,10 +53,9 @@ public class VolatilityUseCase {
         }
 
         String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
-        redisService.setVolatilityReportJob(reportDate, "PENDING");
-
         for (Volatility v : todayVolatility) {
             String jobId = "VOLATILITY_" + reportDate + "_" + v.getStockCode();
+            redisService.setVolatilityReportJob(reportDate, v.getStockCode(), "PENDING");
             reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
                     .jobId(jobId)
                     .stockCode(v.getStockCode())
@@ -71,6 +72,7 @@ public class VolatilityUseCase {
     public void runSingleReportGeneration(SingleReportRequest request) {
         String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
         String jobId = "VOLATILITY_" + reportDate + "_" + request.getStockCode();
+        redisService.setVolatilityReportJob(reportDate, request.getStockCode(), "PENDING");
         reportLambdaClient.invokeCreateReport(ReportLambdaRequestDto.builder()
                 .jobId(jobId)
                 .stockCode(request.getStockCode())
@@ -84,7 +86,7 @@ public class VolatilityUseCase {
     public void handleReportCallback(ReportCallback request) {
         LocalDate reportDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
         volatilityCommandService.updateReportUrl(request.getStockCode(), reportDate, request.getReportUrl());
-        redisService.setVolatilityReportJob(request.getReportDate(), "COMPLETED");
+        redisService.setVolatilityReportJob(request.getReportDate(), request.getStockCode(), "COMPLETED");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/common/config/LambdaConfig.java
+++ b/src/main/java/com/example/demo/common/config/LambdaConfig.java
@@ -1,0 +1,28 @@
+package com.example.demo.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+import java.time.Duration;
+
+@Configuration
+public class LambdaConfig {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public LambdaClient lambdaClient() {
+        return LambdaClient.builder()
+                .region(Region.of(region))
+                .httpClient(ApacheHttpClient.builder()
+                        .socketTimeout(Duration.ofMinutes(6))
+                        .connectionTimeout(Duration.ofSeconds(10))
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/common/consts/StaticVariable.java
+++ b/src/main/java/com/example/demo/common/consts/StaticVariable.java
@@ -24,6 +24,9 @@ public class StaticVariable {
     public static final String XLSX_CONTENT_TYPE =
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     public static final String KOSPI200_FILE_KEY = "kospi200.xlsx";
+    public static final String REPORT_GENERATION_SUCCESS = "success";
+    public static final String REPORT_GENERATION_FAILURE = "failure";
+    public static final String REPORT_GENERATION_PARTIAL_SUCCESS = "PARTIAL_SUCCESS";
 
     //OAuth2
     public static final String KAKAO_OAUTH2_AUTHORIZATION_URI = "/oauth2/authorization/kakao";

--- a/src/main/java/com/example/demo/common/exception/ErrorStatus.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorStatus.java
@@ -26,12 +26,16 @@ public enum ErrorStatus implements BaseErrorCode{
     _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
     _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다."),
 
-    // user (4050-4099)
-    // userPortfolio (4100-4149)
-    // notification (4150-4199)
-    // favoriteStock (4200-4249)
-    // reportRequest (4250-4299)
-    // report (4300-4349)
+    // 도메인별 코드 대역 (각 도메인의 *ErrorStatus에 정의)
+    // user           (4050-4099)  UserErrorStatus
+    // userPortfolio  (4100-4149)  UserPortfolioErrorStatus
+    // notification   (4150-4199)  NotificationErrorStatus
+    // favoriteStock  (4200-4249)  FavoriteStockErrorStatus
+    // stock          (4250-4299)  StockErrorStatus
+    // volatility     (4300-4349)  VolatilityErrorStatus
+    // 인증            (4350-4399)  ErrorStatus (아래 AUTH_*)
+    // kis 연동        (4400-4449)  KisErrorStatus
+    // krx 연동        (4450-4499)  KrxErrorStatus
 
     // 인증 관련 오류 (4350~4399)
     @ExplainError("카카오 로그인 시 이메일 동의를 하지 않아 이메일을 가져오지 못했습니다.")

--- a/src/main/java/com/example/demo/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/demo/common/exception/ExceptionAdvice.java
@@ -1,10 +1,19 @@
 package com.example.demo.common.exception;
 
 import com.example.demo.api.common.dto.ApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
 @RestControllerAdvice
 public class ExceptionAdvice {
 
@@ -14,6 +23,58 @@ public class ExceptionAdvice {
     ) {
 
         Reason reason = e.getErrorReasonHttpStatus();
+
+        return ResponseEntity
+                .status(reason.getHttpStatus())
+                .body(ApiResponseDto.onFailure(
+                        reason.getCode(),
+                        reason.getMessage(),
+                        null
+                ));
+    }
+
+    /** @Valid 검증 실패. 어떤 필드가 왜 틀렸는지 result에 담아 돌려준다. */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto<?>> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e
+    ) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.merge(fieldError.getField(), fieldError.getDefaultMessage(),
+                    (existing, added) -> existing + ", " + added);
+        }
+
+        Reason reason = ErrorStatus._BAD_REQUEST.getReasonHttpStatus();
+
+        return ResponseEntity
+                .status(reason.getHttpStatus())
+                .body(ApiResponseDto.onFailure(
+                        reason.getCode(),
+                        reason.getMessage(),
+                        fieldErrors
+                ));
+    }
+
+    /**
+     * 위에서 잡히지 않은 모든 예외.
+     * Spring MVC가 이미 상태코드를 정한 예외(404, 405, 415 등)는 그 상태를 보존하고,
+     * 그 외에는 500으로 처리하되 내부 메시지를 노출하지 않고 로그로만 남긴다.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto<?>> handleUnexpectedException(
+            Exception e
+    ) {
+        if (e instanceof ErrorResponse errorResponse) {
+            HttpStatusCode status = errorResponse.getStatusCode();
+            log.warn("Spring MVC 예외 발생. status={}, type={}", status, e.getClass().getSimpleName());
+            return ResponseEntity
+                    .status(status)
+                    .body(ApiResponseDto.onFailure(status.value(), e.getMessage(), null));
+        }
+
+        log.error("처리되지 않은 예외 발생", e);
+
+        Reason reason = ErrorStatus._INTERNAL_SERVER_ERROR.getReasonHttpStatus();
 
         return ResponseEntity
                 .status(reason.getHttpStatus())

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -59,4 +59,17 @@ public class RedisService {
         redisTemplate.delete(AUTH_CODE_PREFIX + code);
     }
 
+    // FOR 변동성 리포트 생성 Job 상태 추적
+    private static final String VOLATILITY_REPORT_JOB_PREFIX = "volatility:report:job:";
+
+    public void setVolatilityReportJob(String reportDate, String status) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(VOLATILITY_REPORT_JOB_PREFIX + reportDate, status, Duration.ofHours(48));
+    }
+
+    public String getVolatilityReportJob(String reportDate) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(VOLATILITY_REPORT_JOB_PREFIX + reportDate);
+    }
+
 }

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -62,14 +62,14 @@ public class RedisService {
     // FOR 변동성 리포트 생성 Job 상태 추적
     private static final String VOLATILITY_REPORT_JOB_PREFIX = "volatility:report:job:";
 
-    public void setVolatilityReportJob(String reportDate, String status) {
+    public void setVolatilityReportJob(String reportDate, String stockCode, String status) {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(VOLATILITY_REPORT_JOB_PREFIX + reportDate, status, Duration.ofHours(48));
+        values.set(VOLATILITY_REPORT_JOB_PREFIX + reportDate + ":" + stockCode, status, Duration.ofHours(48));
     }
 
-    public String getVolatilityReportJob(String reportDate) {
+    public String getVolatilityReportJob(String reportDate, String stockCode) {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
-        return values.get(VOLATILITY_REPORT_JOB_PREFIX + reportDate);
+        return values.get(VOLATILITY_REPORT_JOB_PREFIX + reportDate + ":" + stockCode);
     }
 
 }

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -59,17 +59,4 @@ public class RedisService {
         redisTemplate.delete(AUTH_CODE_PREFIX + code);
     }
 
-    // FOR 변동성 리포트 생성 Job 상태 추적
-    private static final String VOLATILITY_REPORT_JOB_PREFIX = "volatility:report:job:";
-
-    public void setVolatilityReportJob(String reportDate, String stockCode, String status) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(VOLATILITY_REPORT_JOB_PREFIX + reportDate + ":" + stockCode, status, Duration.ofHours(48));
-    }
-
-    public String getVolatilityReportJob(String reportDate, String stockCode) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        return values.get(VOLATILITY_REPORT_JOB_PREFIX + reportDate + ":" + stockCode);
-    }
-
 }

--- a/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
@@ -14,17 +14,13 @@ import java.util.Objects;
 @AllArgsConstructor
 public enum StockErrorStatus implements BaseErrorCode {
 
-    //  Entity Stock(4350~4399)
-    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4350, "stock을 찾지 못 했습니다."),
-    STOCK_ALREADY_EXISTS(HttpStatus.CONFLICT, 4351, "이미 등록된 stock입니다."),
-    STOCK_PRICE_NOT_AVAILABLE(HttpStatus.BAD_GATEWAY, 4352, "시가/종가 데이터가 없습니다. 공휴일이거나 거래 정지 종목일 수 있습니다."),
-    STOCK_PRICE_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4353, "KIS API 응답에 데이터가 없습니다."),
-    KIS_API_ERROR(HttpStatus.BAD_GATEWAY, 4354, "KIS API 호출에 실패했습니다."),
-    S3_FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4355, "S3 파일 처리 중 오류가 발생했습니다."),
-    INVALID_FILE(HttpStatus.BAD_REQUEST, 4356, "유효하지 않은 파일입니다. 비어있거나 .xlsx 파일이 아닙니다."),
-    FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, 4357, "파일의 크기가 너무 큽니다."),
-    STOCK_CODE_ERROR(HttpStatus.BAD_REQUEST, 4358, "유효하지 않은 종목 코드 형식입니다."),
-    STOCK_IS_EMPTY(HttpStatus.NOT_FOUND, 4359, "종목 정보가 비어있습니다.");
+    //  Entity Stock(4250~4299)
+    //  KIS 연동 오류는 KisErrorStatus(4400~4449)로 분리했다.
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4250, "stock을 찾지 못 했습니다."),
+    S3_FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4251, "S3 파일 처리 중 오류가 발생했습니다."),
+    INVALID_FILE(HttpStatus.BAD_REQUEST, 4252, "유효하지 않은 파일입니다. 비어있거나 .xlsx 파일이 아닙니다."),
+    FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, 4253, "파일의 크기가 너무 큽니다."),
+    STOCK_IS_EMPTY(HttpStatus.NOT_FOUND, 4254, "종목 정보가 비어있습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
@@ -13,32 +13,12 @@ public class StockHandler extends GeneralException {
         return new StockHandler(StockErrorStatus.STOCK_NOT_FOUND);
     }
 
-    public static StockHandler stockAlreadyExists() {
-        return new StockHandler(StockErrorStatus.STOCK_ALREADY_EXISTS);
-    }
-
-    public static StockHandler stockPriceNotAvailable() {
-        return new StockHandler(StockErrorStatus.STOCK_PRICE_NOT_AVAILABLE);
-    }
-
-    public static StockHandler stockPriceResponseEmpty() {
-        return new StockHandler(StockErrorStatus.STOCK_PRICE_RESPONSE_EMPTY);
-    }
-
-    public static StockHandler kisApiError() {
-        return new StockHandler(StockErrorStatus.KIS_API_ERROR);
-    }
-
     public static StockHandler s3FileIoError() {
         return new StockHandler(StockErrorStatus.S3_FILE_IO_ERROR);
     }
 
     public static StockHandler invalidFile() {
         return new StockHandler(StockErrorStatus.INVALID_FILE);
-    }
-
-    public static StockHandler invalidStockCode() {
-        return new StockHandler(StockErrorStatus.STOCK_CODE_ERROR);
     }
 
     public static StockHandler fileSizeIsToLarge() {

--- a/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
@@ -2,6 +2,8 @@ package com.example.demo.domain.volatility.entity;
 
 import com.example.demo.domain.model.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -21,6 +23,7 @@ public class Volatility extends BaseTimeEntity {
     @Column(name = "stock_name", nullable = false, length = 50)
     private String stockName;
 
+    @Pattern(regexp = "\\d{8}")
     @Column(name = "stock_code", nullable = false, length = 20)
     private String stockCode;
 

--- a/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
@@ -23,7 +23,7 @@ public class Volatility extends BaseTimeEntity {
     @Column(name = "stock_name", nullable = false, length = 50)
     private String stockName;
 
-    @Pattern(regexp = "\\d{8}")
+    @Pattern(regexp = "\\d{6}")
     @Column(name = "stock_code", nullable = false, length = 20)
     private String stockCode;
 

--- a/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
@@ -26,4 +26,8 @@ public class Volatility extends BaseTimeEntity {
 
     @Column(name = "report_url")
     private String reportUrl;
+
+    public void updateReportUrl(String reportUrl) {
+        this.reportUrl = reportUrl;
+    }
 }

--- a/src/main/java/com/example/demo/domain/volatility/entity/VolatilitySignal.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/VolatilitySignal.java
@@ -1,4 +1,4 @@
-package com.example.demo.domain.volatility.service;
+package com.example.demo.domain.volatility.entity;
 
 import java.util.List;
 

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
@@ -19,10 +19,15 @@ public enum VolatilityErrorStatus implements BaseErrorCode {
     VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다."),
     @ExplainError("오늘 /detect를 실행하지 않아 리포트를 생성할 대상 종목이 없습니다.")
     VOLATILITY_NOT_DETECTED_TODAY(HttpStatus.BAD_REQUEST, 4301, "오늘 탐지된 변동성 종목이 없습니다. 먼저 변동성 탐지를 실행해주세요."),
+    @ExplainError("Lambda 호출 자체가 실패했습니다. 네트워크·IAM 권한·스로틀링 등을 확인하세요.")
     REPORT_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4302, "리포트 생성 Lambda 호출에 실패했습니다."),
     @ExplainError("콜백 시크릿 헤더(X-Callback-Secret)가 없거나 일치하지 않습니다.")
     REPORT_CALLBACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4303, "리포트 콜백 인증에 실패했습니다."),
-    REPORT_CALLBACK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4304, "리포트 콜백 요청 형식이 올바르지 않습니다.");
+    REPORT_CALLBACK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4304, "리포트 콜백 요청 형식이 올바르지 않습니다."),
+    @ExplainError("Lambda는 호출됐으나 함수 내부에서 예외가 발생했습니다. Lambda 로그를 확인하세요.")
+    REPORT_LAMBDA_EXECUTION_ERROR(HttpStatus.BAD_GATEWAY, 4305, "리포트 생성 Lambda 실행 중 오류가 발생했습니다."),
+    @ExplainError("조회된 종목이 모두 지표 계산에 실패했습니다. 거래일 데이터가 부족하거나 응답 형식이 바뀌었을 수 있습니다.")
+    VOLATILITY_DETECTION_FAILED(HttpStatus.BAD_GATEWAY, 4306, "변동성 분석에 실패했습니다. 분석 가능한 종목이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
@@ -15,7 +15,9 @@ import java.util.Objects;
 public enum VolatilityErrorStatus implements BaseErrorCode {
 
     // Entity Volatility(4300~4349)
-    VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다.");
+    VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다."),
+    KRX_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4301, "KRX 종목 조회 Lambda 호출에 실패했습니다."),
+    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4302, "KRX 종목 조회 Lambda 응답이 비어있습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityErrorStatus.java
@@ -17,7 +17,14 @@ public enum VolatilityErrorStatus implements BaseErrorCode {
     // Entity Volatility(4300~4349)
     VOLATILITY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "volatility를 찾지 못했습니다."),
     KRX_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4301, "KRX 종목 조회 Lambda 호출에 실패했습니다."),
-    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4302, "KRX 종목 조회 Lambda 응답이 비어있습니다.");
+    KRX_LAMBDA_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, 4302, "KRX 종목 조회 Lambda 응답이 비어있습니다."),
+
+    @ExplainError("오늘 /detect를 실행하지 않아 리포트를 생성할 대상 종목이 없습니다.")
+    VOLATILITY_NOT_DETECTED_TODAY(HttpStatus.BAD_REQUEST, 4303, "오늘 탐지된 변동성 종목이 없습니다. 먼저 변동성 탐지를 실행해주세요."),
+    REPORT_LAMBDA_INVOKE_ERROR(HttpStatus.BAD_GATEWAY, 4304, "리포트 생성 Lambda 호출에 실패했습니다."),
+    @ExplainError("콜백 시크릿 헤더(X-Callback-Secret)가 없거나 일치하지 않습니다.")
+    REPORT_CALLBACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4305, "리포트 콜백 인증에 실패했습니다."),
+    REPORT_CALLBACK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4306, "리포트 콜백 요청 형식이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
@@ -11,6 +11,10 @@ public class VolatilityHandler extends GeneralException {
         super(baseErrorCode);
     }
 
+    public static VolatilityHandler volatilityNotFound() {
+        return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_FOUND);
+    }
+
     public static VolatilityHandler krxLambdaInvokeError() {
         return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_INVOKE_ERROR);
     }

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
@@ -10,4 +10,12 @@ public class VolatilityHandler extends GeneralException {
     public VolatilityHandler(BaseErrorCode baseErrorCode) {
         super(baseErrorCode);
     }
+
+    public static VolatilityHandler krxLambdaInvokeError() {
+        return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_INVOKE_ERROR);
+    }
+
+    public static VolatilityHandler krxLambdaResponseEmpty() {
+        return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_RESPONSE_EMPTY);
+    }
 }

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
@@ -22,4 +22,20 @@ public class VolatilityHandler extends GeneralException {
     public static VolatilityHandler krxLambdaResponseEmpty() {
         return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_RESPONSE_EMPTY);
     }
+
+    public static VolatilityHandler volatilityNotDetectedToday() {
+        return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_DETECTED_TODAY);
+    }
+
+    public static VolatilityHandler reportLambdaInvokeError() {
+        return new VolatilityHandler(VolatilityErrorStatus.REPORT_LAMBDA_INVOKE_ERROR);
+    }
+
+    public static VolatilityHandler reportCallbackUnauthorized() {
+        return new VolatilityHandler(VolatilityErrorStatus.REPORT_CALLBACK_UNAUTHORIZED);
+    }
+
+    public static VolatilityHandler reportCallbackInvalidRequest() {
+        return new VolatilityHandler(VolatilityErrorStatus.REPORT_CALLBACK_INVALID_REQUEST);
+    }
 }

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
@@ -15,12 +15,20 @@ public class VolatilityHandler extends GeneralException {
         return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_FOUND);
     }
 
+    public static VolatilityHandler volatilityDetectionFailed() {
+        return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_DETECTION_FAILED);
+    }
+
     public static VolatilityHandler volatilityNotDetectedToday() {
         return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_DETECTED_TODAY);
     }
 
     public static VolatilityHandler reportLambdaInvokeError() {
         return new VolatilityHandler(VolatilityErrorStatus.REPORT_LAMBDA_INVOKE_ERROR);
+    }
+
+    public static VolatilityHandler reportLambdaExecutionError() {
+        return new VolatilityHandler(VolatilityErrorStatus.REPORT_LAMBDA_EXECUTION_ERROR);
     }
 
     public static VolatilityHandler reportCallbackUnauthorized() {

--- a/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
+++ b/src/main/java/com/example/demo/domain/volatility/exception/VolatilityHandler.java
@@ -15,14 +15,6 @@ public class VolatilityHandler extends GeneralException {
         return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_FOUND);
     }
 
-    public static VolatilityHandler krxLambdaInvokeError() {
-        return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_INVOKE_ERROR);
-    }
-
-    public static VolatilityHandler krxLambdaResponseEmpty() {
-        return new VolatilityHandler(VolatilityErrorStatus.KRX_LAMBDA_RESPONSE_EMPTY);
-    }
-
     public static VolatilityHandler volatilityNotDetectedToday() {
         return new VolatilityHandler(VolatilityErrorStatus.VOLATILITY_NOT_DETECTED_TODAY);
     }

--- a/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
+++ b/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
@@ -2,11 +2,20 @@ package com.example.demo.domain.volatility.repository;
 
 import com.example.demo.domain.volatility.entity.Volatility;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface VolatilityRepository extends JpaRepository<Volatility, Long> {
     List<Volatility> findAllByStockCodeOrderByCreatedDateDesc(String stockCode);
     List<Volatility> findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(LocalDateTime start, LocalDateTime end);
+    Optional<Volatility> findFirstByStockCodeAndCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(String stockCode, LocalDateTime start, LocalDateTime end);
+
+    @Modifying
+    @Query("DELETE FROM Volatility v WHERE v.createdDate >= :start AND v.createdDate < :end")
+    void deleteAllByCreatedDateBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.volatility.service;
 
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
+
 import java.time.LocalDate;
 import java.util.List;
 

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
@@ -1,7 +1,9 @@
 package com.example.demo.domain.volatility.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface VolatilityCommandService {
     void saveTopVolatilityStocks(List<VolatilitySignal> topSignals);
+    void updateReportUrl(String stockCode, LocalDate reportDate, String reportUrl);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
@@ -1,4 +1,7 @@
 package com.example.demo.domain.volatility.service;
 
+import java.util.List;
+
 public interface VolatilityCommandService {
+    void saveTopVolatilityStocks(List<VolatilitySignal> topSignals);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.volatility.service;
 
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.repository.VolatilityRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -1,4 +1,31 @@
 package com.example.demo.domain.volatility.service;
 
-public class VolatilityCommandServiceImpl {
+import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.repository.VolatilityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class VolatilityCommandServiceImpl implements VolatilityCommandService {
+
+    private final VolatilityRepository volatilityRepository;
+
+    @Override
+    public void saveTopVolatilityStocks(List<VolatilitySignal> topSignals) {
+        List<Volatility> volatilities = topSignals.stream()
+                .map(signal -> Volatility.builder()
+                        .stockCode(signal.stockCode())
+                        .stockName(signal.stockName())
+                        .reportUrl(null)
+                        .build())
+                .collect(Collectors.toList());
+
+        volatilityRepository.saveAll(volatilities);
+    }
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -1,13 +1,18 @@
 package com.example.demo.domain.volatility.service;
 
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.repository.VolatilityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static java.time.LocalDate.now;
 
 @Service
 @Transactional
@@ -18,6 +23,10 @@ public class VolatilityCommandServiceImpl implements VolatilityCommandService {
 
     @Override
     public void saveTopVolatilityStocks(List<VolatilitySignal> topSignals) {
+        LocalDateTime start = now().atStartOfDay();
+        LocalDateTime end = now().plusDays(1).atStartOfDay();
+        volatilityRepository.deleteAllByCreatedDateBetween(start, end);
+
         List<Volatility> volatilities = topSignals.stream()
                 .map(signal -> Volatility.builder()
                         .stockCode(signal.stockCode())
@@ -27,5 +36,18 @@ public class VolatilityCommandServiceImpl implements VolatilityCommandService {
                 .collect(Collectors.toList());
 
         volatilityRepository.saveAll(volatilities);
+    }
+
+    @Override
+    public void updateReportUrl(String stockCode, LocalDate reportDate, String reportUrl) {
+        LocalDateTime start = reportDate.atStartOfDay();
+        LocalDateTime end = reportDate.plusDays(1).atStartOfDay();
+
+        Volatility volatility = volatilityRepository
+                .findFirstByStockCodeAndCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(
+                        stockCode, start, end)
+                .orElseThrow(VolatilityHandler::volatilityNotFound);
+
+        volatility.updateReportUrl(reportUrl);
     }
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -24,8 +24,9 @@ public class VolatilityCommandServiceImpl implements VolatilityCommandService {
 
     @Override
     public void saveTopVolatilityStocks(List<VolatilitySignal> topSignals) {
-        LocalDateTime start = now().atStartOfDay();
-        LocalDateTime end = now().plusDays(1).atStartOfDay();
+        LocalDate today = now();
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.plusDays(1).atStartOfDay();
         volatilityRepository.deleteAllByCreatedDateBetween(start, end);
 
         List<Volatility> volatilities = topSignals.stream()

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.volatility.service;
+
+import java.util.List;
+
+public interface VolatilityDetectionService {
+
+    /** KOSPI 시총 상위 topN 종목을 분석해 종목별 변동성 신호를 반환한다. */
+    List<VolatilitySignal> detect(int topN);
+
+    /** 분석 결과 중 alert=true인 종목만, 변동성 점수(0.7)와 시총 가중치(0.3)를 결합해 상위 topN개를 선정한다. */
+    List<VolatilitySignal> selectTop(List<VolatilitySignal> signals, int universeSize, int topN);
+}

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.volatility.service;
 
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
+
 import java.util.List;
 
 public interface VolatilityDetectionService {

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
 import com.example.demo.api.krx.service.KrxService;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.example.demo.domain.volatility.util.VolatilityAlertEvaluator;
 import com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
@@ -1,0 +1,83 @@
+package com.example.demo.domain.volatility.service;
+
+import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
+import com.example.demo.api.krx.service.KrxService;
+import com.example.demo.domain.volatility.util.VolatilityAlertEvaluator;
+import com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VolatilityDetectionServiceImpl implements VolatilityDetectionService {
+
+    // score(변동성)와 marketCapWeight(시총)의 결합 비중. 변동성 리포트의 핵심 가치(뚜렷한 변동 우선)를 지키기 위해
+    // 변동성 쪽에 더 큰 비중을 둔다.
+    private static final double COMBINED_SCORE_WEIGHT = 0.7;
+    private static final double MARKET_CAP_WEIGHT = 0.3;
+
+    private final KrxService krxService;
+
+    @Override
+    public List<VolatilitySignal> detect(int topN) {
+        KrxOhlcvResponseDto response = krxService.getTopMarketCapOhlcv(topN);
+
+        List<VolatilitySignal> signals = new ArrayList<>();
+        for (KrxOhlcvResponseDto.StockOhlcv stock : response.getStocks()) {
+            try {
+                signals.add(analyze(stock));
+            } catch (Exception e) {
+                log.warn("변동성 분석 실패, 종목 스킵. stockCode={}, reason={}", stock.getStockCode(), e.getMessage());
+            }
+        }
+        return signals;
+    }
+
+    @Override
+    public List<VolatilitySignal> selectTop(List<VolatilitySignal> signals, int universeSize, int topN) {
+        return signals.stream()
+                .filter(VolatilitySignal::alert)
+                .sorted(Comparator.comparingDouble(
+                        (VolatilitySignal s) -> combinedScore(s, universeSize)).reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
+    private double combinedScore(VolatilitySignal signal, int universeSize) {
+        double marketCapWeight = (universeSize - signal.marketCapRank() + 1) / (double) universeSize;
+        return COMBINED_SCORE_WEIGHT * signal.score() + MARKET_CAP_WEIGHT * marketCapWeight;
+    }
+
+    /**
+     * KRX Lambda가 이미 정제(0값 행 제거)·트리밍(최근 60거래일)까지 마친 배열을 내려주므로,
+     * 추가 가공 없이 바로 지표 계산에 사용한다.
+     */
+    private VolatilitySignal analyze(KrxOhlcvResponseDto.StockOhlcv stock) {
+        VolatilityIndicatorCalculator.IndicatorSnapshot snapshot = VolatilityIndicatorCalculator.calculate(
+                stock.getClose(), stock.getHigh(), stock.getLow(), stock.getVolume());
+        VolatilityAlertEvaluator.AlertResult alertResult = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        return new VolatilitySignal(
+                stock.getStockCode(),
+                stock.getStockName(),
+                stock.getMarketCapRank(),
+                snapshot.dailyReturnPct(),
+                snapshot.intradayRangePct(),
+                snapshot.vol20AnnualizedPct(),
+                snapshot.bbPercentB(),
+                snapshot.bbWidthPct(),
+                snapshot.volumeSpikeRatio(),
+                snapshot.vol20Quantile(),
+                alertResult.score(),
+                alertResult.alert(),
+                alertResult.reasons()
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
@@ -38,6 +38,13 @@ public class VolatilityDetectionServiceImpl implements VolatilityDetectionServic
                 log.warn("변동성 분석 실패, 종목 스킵. stockCode={}, reason={}", stock.getStockCode(), e.getMessage());
             }
         }
+
+        int received = response.getStocks().size();
+        int skipped = received - signals.size();
+        if (skipped > 0) {
+            log.warn("변동성 분석 스킵 {}건 / 수신 {}건 (요청 {}건)", skipped, received, topN);
+        }
+
         return signals;
     }
 

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface VolatilityQueryService {
     List<Volatility> getAllVolatilityByDate(LocalDateTime start, LocalDateTime end);
     List<Volatility> getAllVolatilityByCode(String stockCode);
+    List<Volatility> getTodayVolatility();
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
@@ -29,8 +29,9 @@ public class VolatilityQueryServiceImpl implements VolatilityQueryService {
 
     @Override
     public List<Volatility> getTodayVolatility() {
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDate today = LocalDate.now();
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.plusDays(1).atStartOfDay();
         return volatilityRepository
                 .findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(start, end);
     }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,5 +25,13 @@ public class VolatilityQueryServiceImpl implements VolatilityQueryService {
     @Override
     public List<Volatility> getAllVolatilityByCode(String stockCode) {
         return volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc(stockCode);
+    }
+
+    @Override
+    public List<Volatility> getTodayVolatility() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
+        return volatilityRepository
+                .findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(start, end);
     }
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilitySignal.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilitySignal.java
@@ -1,0 +1,24 @@
+package com.example.demo.domain.volatility.service;
+
+import java.util.List;
+
+/**
+ * 종목 하나에 대한 변동성 분석 결과. DB 엔티티가 아닌 순수 반환용 값 객체.
+ * marketCapRank는 유니버스 조회 시의 시총 순위(1위부터)로, top10 결합 점수 계산에 쓰인다.
+ */
+public record VolatilitySignal(
+        String stockCode,
+        String stockName,
+        int marketCapRank,
+        double dailyReturnPct,
+        double intradayRangePct,
+        double vol20AnnualizedPct,
+        double bbPercentB,
+        double bbWidthPct,
+        double volumeSpikeRatio,
+        double vol20Quantile,
+        double score,
+        boolean alert,
+        List<String> reasons
+) {
+}

--- a/src/main/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluator.java
+++ b/src/main/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluator.java
@@ -1,0 +1,89 @@
+package com.example.demo.domain.volatility.util;
+
+import com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator.IndicatorSnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 변동성 알림 조건 평가. volatility_detector의 evaluate_alert 포팅 + 가중치 스코어링.
+ * 알림 트리거(alert)는 원본과 동일하게 "조건 하나라도 충족 시 true".
+ * score는 가중치 합(0.0~1.0)으로, 심각도 정렬 용도.
+ */
+public class VolatilityAlertEvaluator {
+
+    public static final String REASON_DAILY_RETURN = "daily_return_abs_ge_5";
+    public static final String REASON_INTRADAY_RANGE = "intraday_range_ge_5";
+    public static final String REASON_VOLUME_SPIKE = "volume_spike_ge_2";
+    public static final String REASON_BB_HIGH = "bb_percent_b_ge_0.9";
+    public static final String REASON_BB_LOW = "bb_percent_b_le_0.1";
+    public static final String REASON_VOL20_QUANTILE = "vol20_quantile_ge_0.8";
+
+    private static final double DAILY_RETURN_ABS_THRESHOLD = 5.0;
+    private static final double INTRADAY_RANGE_THRESHOLD = 5.0;
+    private static final double VOLUME_SPIKE_THRESHOLD = 2.0;
+    private static final double BB_PERCENT_B_HIGH = 0.9;
+    private static final double BB_PERCENT_B_LOW = 0.1;
+    private static final double VOL20_QUANTILE_THRESHOLD = 0.8;
+
+    // 지표가 "변동성 자체"를 얼마나 직접 반영하는지 기준으로 부여한 가중치. 합계 1.0.
+    private static final double WEIGHT_VOL20_QUANTILE = 0.30;
+    private static final double WEIGHT_INTRADAY_RANGE = 0.25;
+    private static final double WEIGHT_VOLUME_SPIKE = 0.20;
+    private static final double WEIGHT_DAILY_RETURN = 0.15;
+    private static final double WEIGHT_BB_EXTREME = 0.10;
+
+    private VolatilityAlertEvaluator() {
+    }
+
+    public record AlertResult(double score, boolean alert, List<String> reasons) {
+    }
+
+    public static AlertResult evaluate(IndicatorSnapshot snapshot) {
+        List<String> reasons = new ArrayList<>();
+        double score = 0.0;
+
+        if (!Double.isNaN(snapshot.dailyReturnPct())
+                && Math.abs(snapshot.dailyReturnPct()) >= DAILY_RETURN_ABS_THRESHOLD) {
+            reasons.add(REASON_DAILY_RETURN);
+            score += WEIGHT_DAILY_RETURN;
+        }
+
+        if (!Double.isNaN(snapshot.intradayRangePct())
+                && snapshot.intradayRangePct() >= INTRADAY_RANGE_THRESHOLD) {
+            reasons.add(REASON_INTRADAY_RANGE);
+            score += WEIGHT_INTRADAY_RANGE;
+        }
+
+        if (!Double.isNaN(snapshot.volumeSpikeRatio())
+                && snapshot.volumeSpikeRatio() >= VOLUME_SPIKE_THRESHOLD) {
+            reasons.add(REASON_VOLUME_SPIKE);
+            score += WEIGHT_VOLUME_SPIKE;
+        }
+
+        // bb_percent_b 상단/하단은 같은 지표의 양끝단이라 가중치는 한 번만 반영.
+        boolean bbExtreme = false;
+        if (!Double.isNaN(snapshot.bbPercentB())) {
+            if (snapshot.bbPercentB() >= BB_PERCENT_B_HIGH) {
+                reasons.add(REASON_BB_HIGH);
+                bbExtreme = true;
+            }
+            if (snapshot.bbPercentB() <= BB_PERCENT_B_LOW) {
+                reasons.add(REASON_BB_LOW);
+                bbExtreme = true;
+            }
+        }
+        if (bbExtreme) {
+            score += WEIGHT_BB_EXTREME;
+        }
+
+        if (!Double.isNaN(snapshot.vol20Quantile())
+                && snapshot.vol20Quantile() >= VOL20_QUANTILE_THRESHOLD) {
+            reasons.add(REASON_VOL20_QUANTILE);
+            score += WEIGHT_VOL20_QUANTILE;
+        }
+
+        boolean alert = !reasons.isEmpty();
+        return new AlertResult(score, alert, reasons);
+    }
+}

--- a/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
+++ b/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
@@ -1,0 +1,157 @@
+package com.example.demo.domain.volatility.util;
+
+/**
+ * 변동성 지표 순수 계산 유틸.
+ * 네트워크/DB 의존 없음 — volatility_detector/indicators.py 포팅.
+ * 입력 배열은 날짜 오름차순(index 0이 가장 과거)이어야 한다.
+ */
+public class VolatilityIndicatorCalculator {
+
+    static final int ROLLING_WINDOW = 20;
+    private static final double TRADING_DAYS_PER_YEAR = 252.0;
+
+    /** calculate()가 요구하는 최소 유효 거래일 수. 오케스트레이션 단계의 스킵 기준으로 재사용. */
+    public static final int MIN_VALID_TRADING_DAYS = ROLLING_WINDOW;
+
+    private VolatilityIndicatorCalculator() {
+    }
+
+    public record IndicatorSnapshot(
+            double dailyReturnPct,
+            double intradayRangePct,
+            double vol20AnnualizedPct,
+            double bbPercentB,
+            double bbWidthPct,
+            double volumeSpikeRatio,
+            double vol20Quantile
+    ) {
+    }
+
+    public static IndicatorSnapshot calculate(double[] close, double[] high, double[] low, double[] volume) {
+        int n = close.length;
+        if (n < ROLLING_WINDOW) {
+            throw new IllegalArgumentException("최소 " + ROLLING_WINDOW + "개의 거래일 데이터가 필요합니다.");
+        }
+
+        double[] returns = dailyReturns(close);
+        double[] vol20Series = rollingAnnualizedVol(returns);
+
+        return new IndicatorSnapshot(
+                dailyReturnPct(close),
+                intradayRangePct(high[n - 1], low[n - 1], close[n - 1]),
+                vol20Series[vol20Series.length - 1],
+                bbPercentB(close),
+                bbWidthPct(close),
+                volumeSpikeRatio(volume),
+                percentileRank(vol20Series, vol20Series[vol20Series.length - 1])
+        );
+    }
+
+    /** 마지막 거래일의 일간수익률(%). close.length >= 2 필요. */
+    static double dailyReturnPct(double[] close) {
+        int n = close.length;
+        return (close[n - 1] / close[n - 2] - 1.0) * 100.0;
+    }
+
+    /** 당일 고가-저가 변동폭(%). */
+    static double intradayRangePct(double high, double low, double close) {
+        return (high - low) / close * 100.0;
+    }
+
+    /** 최근 20일 종가 기준 볼린저밴드 %B. close.length >= ROLLING_WINDOW 필요. */
+    static double bbPercentB(double[] close) {
+        int n = close.length;
+        double ma20 = mean(close, n - ROLLING_WINDOW, n);
+        double std20 = stddev(close, n - ROLLING_WINDOW, n);
+        double upper = ma20 + 2.0 * std20;
+        double lower = ma20 - 2.0 * std20;
+        double band = upper - lower;
+        return band == 0.0 ? Double.NaN : (close[n - 1] - lower) / band;
+    }
+
+    /** 최근 20일 종가 기준 볼린저밴드 폭(%). close.length >= ROLLING_WINDOW 필요. */
+    static double bbWidthPct(double[] close) {
+        int n = close.length;
+        double ma20 = mean(close, n - ROLLING_WINDOW, n);
+        double std20 = stddev(close, n - ROLLING_WINDOW, n);
+        double band = 4.0 * std20;
+        return ma20 == 0.0 ? Double.NaN : band / ma20 * 100.0;
+    }
+
+    /** 최근 20일 평균 거래량 대비 당일 거래량 배수. volume.length >= ROLLING_WINDOW 필요. */
+    static double volumeSpikeRatio(double[] volume) {
+        int n = volume.length;
+        double volMa20 = mean(volume, n - ROLLING_WINDOW, n);
+        return volMa20 == 0.0 ? Double.NaN : volume[n - 1] / volMa20;
+    }
+
+    static double[] dailyReturns(double[] close) {
+        double[] returns = new double[close.length - 1];
+        for (int i = 1; i < close.length; i++) {
+            returns[i - 1] = close[i] / close[i - 1] - 1.0;
+        }
+        return returns;
+    }
+
+    /** returns 배열에 20일 롤링 표준편차를 연환산(%)해 시계열로 반환. 윈도우를 못 채우면 NaN 1개짜리 배열. */
+    static double[] rollingAnnualizedVol(double[] returns) {
+        int count = returns.length - ROLLING_WINDOW + 1;
+        if (count < 1) {
+            return new double[]{Double.NaN};
+        }
+        double[] result = new double[count];
+        for (int i = 0; i < count; i++) {
+            double std = stddev(returns, i, i + ROLLING_WINDOW);
+            result[i] = std * Math.sqrt(TRADING_DAYS_PER_YEAR) * 100.0;
+        }
+        return result;
+    }
+
+    private static double mean(double[] arr, int fromInclusive, int toExclusive) {
+        double sum = 0.0;
+        int len = toExclusive - fromInclusive;
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            sum += arr[i];
+        }
+        return sum / len;
+    }
+
+    /** 표본표준편차 (ddof=1, pandas 기본값과 동일). */
+    private static double stddev(double[] arr, int fromInclusive, int toExclusive) {
+        int len = toExclusive - fromInclusive;
+        if (len < 2) {
+            return 0.0;
+        }
+        double m = mean(arr, fromInclusive, toExclusive);
+        double sumSq = 0.0;
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            double diff = arr[i] - m;
+            sumSq += diff * diff;
+        }
+        return Math.sqrt(sumSq / (len - 1));
+    }
+
+    /**
+     * pandas {@code Series.rank(pct=True)}의 근사치 — 동률은 평균 순위로 처리.
+     * series 원소가 2개 미만이거나 latest가 NaN이면 순위가 정의되지 않아 NaN 반환.
+     */
+    static double percentileRank(double[] series, double latest) {
+        if (series.length < 2 || Double.isNaN(latest)) {
+            return Double.NaN;
+        }
+        int less = 0;
+        int equal = 0;
+        for (double v : series) {
+            if (Double.isNaN(v)) {
+                continue;
+            }
+            if (v < latest) {
+                less++;
+            } else if (v == latest) {
+                equal++;
+            }
+        }
+        double avgRank = less + (equal + 1) / 2.0;
+        return avgRank / series.length;
+    }
+}

--- a/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
+++ b/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
@@ -10,8 +10,9 @@ public class VolatilityIndicatorCalculator {
     static final int ROLLING_WINDOW = 20;
     private static final double TRADING_DAYS_PER_YEAR = 252.0;
 
-    /** calculate()가 요구하는 최소 유효 거래일 수. 오케스트레이션 단계의 스킵 기준으로 재사용. */
-    public static final int MIN_VALID_TRADING_DAYS = ROLLING_WINDOW;
+    /** calculate()가 요구하는 최소 유효 거래일 수. 오케스트레이션 단계의 스킵 기준으로 재사용.
+     * ROLLING_WINDOW + 2: dailyReturns()가 n-1개를 생성하고, percentileRank()는 2개 이상 필요. */
+    public static final int MIN_VALID_TRADING_DAYS = ROLLING_WINDOW + 2;
 
     private VolatilityIndicatorCalculator() {
     }
@@ -28,9 +29,17 @@ public class VolatilityIndicatorCalculator {
     }
 
     public static IndicatorSnapshot calculate(double[] close, double[] high, double[] low, double[] volume) {
+        if (close == null || high == null || low == null || volume == null) {
+            throw new IllegalArgumentException("OHLCV 배열이 null입니다.");
+        }
         int n = close.length;
-        if (n < ROLLING_WINDOW) {
-            throw new IllegalArgumentException("최소 " + ROLLING_WINDOW + "개의 거래일 데이터가 필요합니다.");
+        if (n < MIN_VALID_TRADING_DAYS) {
+            throw new IllegalArgumentException("최소 " + MIN_VALID_TRADING_DAYS + "개의 거래일 데이터가 필요합니다.");
+        }
+        if (high.length != n || low.length != n || volume.length != n) {
+            throw new IllegalArgumentException(
+                    "OHLCV 배열 길이가 일치하지 않습니다. close=" + n
+                            + " high=" + high.length + " low=" + low.length + " volume=" + volume.length);
         }
 
         double[] returns = dailyReturns(close);
@@ -136,22 +145,27 @@ public class VolatilityIndicatorCalculator {
      * series 원소가 2개 미만이거나 latest가 NaN이면 순위가 정의되지 않아 NaN 반환.
      */
     static double percentileRank(double[] series, double latest) {
-        if (series.length < 2 || Double.isNaN(latest)) {
+        if (Double.isNaN(latest)) {
             return Double.NaN;
         }
         int less = 0;
         int equal = 0;
+        int validCount = 0;
         for (double v : series) {
             if (Double.isNaN(v)) {
                 continue;
             }
+            validCount++;
             if (v < latest) {
                 less++;
             } else if (v == latest) {
                 equal++;
             }
         }
+        if (validCount < 2) {
+            return Double.NaN;
+        }
         double avgRank = less + (equal + 1) / 2.0;
-        return avgRank / series.length;
+        return avgRank / validCount;
     }
 }

--- a/src/main/java/com/example/demo/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/config/SecurityConfig.java
@@ -65,6 +65,8 @@ public class SecurityConfig {
                                 "/api/v1/test/health-check"
                         ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
+                        // S3 이벤트로 트리거되는 Lambda가 호출하는 콜백. JWT 대신 X-Callback-Secret 헤더로 검증한다.
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/volatility/report/callback").permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,10 @@ kis:
   app-key: ${KIS_APP_KEY}
   app-secret: ${KIS_APP_SECRET}
 
+krx:
+  lambda:
+    function-name: ${KRX_LAMBDA_FUNCTION_NAME:krxOhlcvFetcher}
+
 cloud:
   aws:
     region:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,10 @@ krx:
   lambda:
     function-name: ${KRX_LAMBDA_FUNCTION_NAME:krxOhlcvFetcher}
 
+report:
+  lambda:
+    function-name: ${REPORT_LAMBDA_FUNCTION_NAME:CreateReportByStockCode}
+
 cloud:
   aws:
     region:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,8 @@ krx:
 report:
   lambda:
     function-name: ${REPORT_LAMBDA_FUNCTION_NAME:CreateReportByStockCode}
+  callback:
+    secret: ${REPORT_CALLBACK_SECRET}
 
 cloud:
   aws:

--- a/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
+++ b/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
@@ -1,0 +1,83 @@
+package com.example.demo.api.volatility.service;
+
+import com.example.demo.api.report.client.ReportLambdaClient;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
+import com.example.demo.domain.volatility.exception.VolatilityErrorStatus;
+import com.example.demo.domain.volatility.service.VolatilityCommandService;
+import com.example.demo.domain.volatility.service.VolatilityDetectionService;
+import com.example.demo.domain.volatility.service.VolatilityQueryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * runDetection의 저장 가드 검증.
+ * detect()는 종목별 실패를 스킵하므로 전 종목이 실패해도 빈 리스트를 정상 반환한다.
+ * 그 상태로 저장까지 진행하면 saveTopVolatilityStocks가 오늘 기록을 지우기만 하고 끝나므로,
+ * 저장 이전에 중단되는지를 확인한다.
+ */
+class VolatilityUseCaseTest {
+
+    private final VolatilityQueryService queryService = Mockito.mock(VolatilityQueryService.class);
+    private final VolatilityDetectionService detectionService = Mockito.mock(VolatilityDetectionService.class);
+    private final VolatilityCommandService commandService = Mockito.mock(VolatilityCommandService.class);
+    private final ReportLambdaClient reportLambdaClient = Mockito.mock(ReportLambdaClient.class);
+
+    private final VolatilityUseCase useCase =
+            new VolatilityUseCase(queryService, detectionService, commandService, reportLambdaClient);
+
+    @Test
+    void 전_종목_분석에_실패하면_저장하지_않고_예외를_던진다() {
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of());
+
+        assertThatThrownBy(useCase::runDetection)
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorReasonHttpStatus().getCode())
+                .isEqualTo(VolatilityErrorStatus.VOLATILITY_DETECTION_FAILED.getCode());
+
+        // 오늘 기록을 지우는 저장 경로에 진입하면 안 된다.
+        verify(commandService, never()).saveTopVolatilityStocks(any());
+    }
+
+    @Test
+    void 분석은_됐지만_알림_종목이_없으면_빈_결과로_저장한다() {
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of(signal("005930")));
+        Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        var result = useCase.runDetection();
+
+        assertThat(result.getDetectedCount()).isZero();
+        verify(commandService).saveTopVolatilityStocks(List.of());
+    }
+
+    @Test
+    void 알림_종목이_있으면_그대로_저장한다() {
+        VolatilitySignal detected = signal("005930");
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of(detected));
+        Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of(detected));
+
+        var result = useCase.runDetection();
+
+        assertThat(result.getDetectedCount()).isEqualTo(1);
+        assertThat(result.getStocks()).singleElement()
+                .satisfies(s -> assertThat(s.getStockCode()).isEqualTo("005930"));
+        verify(commandService).saveTopVolatilityStocks(List.of(detected));
+    }
+
+    private VolatilitySignal signal(String stockCode) {
+        return new VolatilitySignal(
+                stockCode, "삼성전자", 1,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.5, true, List.of()
+        );
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
@@ -63,11 +63,25 @@ class VolatilityCommandServiceImplTest {
     }
 
     @Test
-    void 같은_종목이_다시_선정되면_새_row로_쌓인다() {
+    void 같은_날_다시_실행하면_오늘_기록을_교체한다() {
+        // 탐지는 하루 한 번이 기준이므로 재실행은 누적이 아니라 교체다(stock_code 중복 방지).
         volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
         volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
 
-        assertThat(volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc("005930")).hasSize(2);
+        assertThat(volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc("005930")).hasSize(1);
+    }
+
+    @Test
+    void 재실행_시_이전_선정_종목은_남지_않는다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(
+                signal("005930", "삼성전자"),
+                signal("000660", "SK하이닉스")
+        ));
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("035420", "NAVER")));
+
+        assertThat(volatilityRepository.findAll())
+                .extracting(Volatility::getStockCode)
+                .containsExactly("035420");
     }
 
     @Test

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
@@ -1,0 +1,86 @@
+package com.example.demo.domain.volatility.service;
+
+import com.example.demo.common.config.JpaAuditingConfig;
+import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.repository.VolatilityRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 알림 종목 저장 로직의 H2 기반 테스트.
+ * application.yml이 요구하는 외부 DATABASE_* 환경변수를 쓰지 않도록 H2 설정을 직접 주입한다.
+ */
+@DataJpaTest
+@Import({VolatilityCommandServiceImpl.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:volatility;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class VolatilityCommandServiceImplTest {
+
+    @Autowired
+    private VolatilityCommandService volatilityCommandService;
+
+    @Autowired
+    private VolatilityRepository volatilityRepository;
+
+    @Test
+    void top10_종목의_코드와_이름만_저장되고_reportUrl은_null() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(
+                signal("005930", "삼성전자"),
+                signal("000660", "SK하이닉스")
+        ));
+
+        List<Volatility> saved = volatilityRepository.findAll();
+
+        assertThat(saved).hasSize(2);
+        assertThat(saved).extracting(Volatility::getStockCode)
+                .containsExactlyInAnyOrder("005930", "000660");
+        assertThat(saved).extracting(Volatility::getStockName)
+                .containsExactlyInAnyOrder("삼성전자", "SK하이닉스");
+        assertThat(saved).allSatisfy(v -> assertThat(v.getReportUrl()).isNull());
+    }
+
+    @Test
+    void createdDate가_자동으로_채워져_날짜별_조회가_가능하다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
+
+        List<Volatility> saved = volatilityRepository.findAll();
+
+        assertThat(saved).singleElement()
+                .satisfies(v -> assertThat(v.getCreatedDate()).isNotNull());
+    }
+
+    @Test
+    void 같은_종목이_다시_선정되면_새_row로_쌓인다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
+
+        assertThat(volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc("005930")).hasSize(2);
+    }
+
+    @Test
+    void 빈_목록이면_아무것도_저장하지_않는다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of());
+
+        assertThat(volatilityRepository.findAll()).isEmpty();
+    }
+
+    private VolatilitySignal signal(String stockCode, String stockName) {
+        return new VolatilitySignal(
+                stockCode, stockName, 1,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.5, true, List.of()
+        );
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.common.config.JpaAuditingConfig;
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.example.demo.domain.volatility.repository.VolatilityRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
 import com.example.demo.api.krx.service.KrxService;
+import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.example.demo.domain.volatility.service;
+
+import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
+import com.example.demo.api.krx.service.KrxService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * top10 선정 로직(selectTop)과 KRX Lambda 응답을 지표 계산으로 넘기는 오케스트레이션(detect) 유닛테스트.
+ * OHLCV 정제(0값 제거)·60거래일 트리밍은 KRX Lambda(Python) 책임으로 이관됐으므로 여기서는 검증하지 않는다.
+ */
+class VolatilityDetectionServiceImplTest {
+
+    private static final int UNIVERSE_SIZE = 100;
+
+    private final KrxService krxService = Mockito.mock(KrxService.class);
+    private final VolatilityDetectionService service = new VolatilityDetectionServiceImpl(krxService);
+
+    @Test
+    void alert가_아닌_종목은_후보에서_제외() {
+        VolatilitySignal alerted = signal("005930", 1, 0.5, true);
+        VolatilitySignal notAlerted = signal("000660", 2, 0.9, false);
+
+        List<VolatilitySignal> top = service.selectTop(List.of(alerted, notAlerted), UNIVERSE_SIZE, 10);
+
+        assertThat(top).containsExactly(alerted);
+    }
+
+    @Test
+    void 후보가_10개_미만이면_있는_만큼만_반환() {
+        List<VolatilitySignal> signals = List.of(
+                signal("A", 1, 0.9, true),
+                signal("B", 2, 0.8, true),
+                signal("C", 3, 0.7, true)
+        );
+
+        List<VolatilitySignal> top = service.selectTop(signals, UNIVERSE_SIZE, 10);
+
+        assertThat(top).hasSize(3);
+    }
+
+    @Test
+    void 후보가_10개_초과면_상위_10개만_반환() {
+        List<VolatilitySignal> signals = IntStream.rangeClosed(1, 15)
+                .mapToObj(i -> signal("CODE" + i, i, i / 15.0, true))
+                .collect(Collectors.toList());
+
+        List<VolatilitySignal> top = service.selectTop(signals, UNIVERSE_SIZE, 10);
+
+        assertThat(top).hasSize(10);
+    }
+
+    @Test
+    void combinedScore는_변동성점수0_7_시총가중치0_3으로_정렬된다() {
+        // 시총 1위(rank=1, marketCapWeight=1.0)이지만 score가 아주 낮은 종목
+        VolatilitySignal highCapLowScore = signal("HIGHCAP", 1, 0.05, true);
+        // 시총 100위(rank=100, marketCapWeight=0.01)이지만 score가 매우 높은 종목
+        VolatilitySignal lowCapHighScore = signal("LOWCAP", 100, 0.9, true);
+
+        // combinedScore(highCapLowScore) = 0.7*0.05 + 0.3*1.00 = 0.335
+        // combinedScore(lowCapHighScore)  = 0.7*0.90 + 0.3*0.01 = 0.633
+        List<VolatilitySignal> top = service.selectTop(
+                List.of(highCapLowScore, lowCapHighScore), UNIVERSE_SIZE, 10);
+
+        assertThat(top).containsExactly(lowCapHighScore, highCapLowScore);
+    }
+
+    @Test
+    void detect는_KRX_Lambda_응답의_각_종목을_지표계산으로_넘겨_신호를_만든다() throws Exception {
+        Mockito.when(krxService.getTopMarketCapOhlcv(ArgumentMatchers.anyInt()))
+                .thenReturn(ohlcvResponse(stockJson("005930", "삼성전자", 1, syntheticCloses(60))));
+
+        List<VolatilitySignal> detected = service.detect(1);
+
+        assertThat(detected).hasSize(1);
+        VolatilitySignal signal = detected.get(0);
+        assertThat(signal.stockCode()).isEqualTo("005930");
+        assertThat(signal.stockName()).isEqualTo("삼성전자");
+        assertThat(signal.marketCapRank()).isEqualTo(1);
+        assertThat(signal.dailyReturnPct()).isNotNaN();
+    }
+
+    @Test
+    void 한_종목_계산이_실패해도_나머지_종목은_정상_처리된다() throws Exception {
+        // 60개 미만 배열은 VolatilityIndicatorCalculator.calculate()가 IllegalArgumentException을 던짐
+        String broken = stockJson("000660", "SK하이닉스", 2, syntheticCloses(5));
+        String valid = stockJson("005930", "삼성전자", 1, syntheticCloses(60));
+        Mockito.when(krxService.getTopMarketCapOhlcv(ArgumentMatchers.anyInt()))
+                .thenReturn(ohlcvResponse(broken, valid));
+
+        List<VolatilitySignal> detected = service.detect(2);
+
+        assertThat(detected).hasSize(1);
+        assertThat(detected.get(0).stockCode()).isEqualTo("005930");
+    }
+
+    private VolatilitySignal signal(String stockCode, int rank, double score, boolean alert) {
+        return new VolatilitySignal(
+                stockCode, stockCode + "_name", rank,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                score, alert, List.of()
+        );
+    }
+
+    private double[] syntheticCloses(int n) {
+        double[] close = new double[n];
+        for (int i = 0; i < n; i++) {
+            close[i] = 1000.0 + (i % 5) * 4.0;
+        }
+        return close;
+    }
+
+    private String stockJson(String stockCode, String stockName, int rank, double[] close) {
+        String closeJson = java.util.Arrays.stream(close)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining(","));
+        return String.format(
+                "{\"stock_code\":\"%s\",\"stock_name\":\"%s\",\"market_cap_rank\":%d,"
+                        + "\"close\":[%s],\"high\":[%s],\"low\":[%s],\"volume\":[%s]}",
+                stockCode, stockName, rank, closeJson, closeJson, closeJson, closeJson);
+    }
+
+    private KrxOhlcvResponseDto ohlcvResponse(String... stockJsonEntries) throws Exception {
+        String json = "{\"effective_trade_date\":\"20260731\",\"universe_size\":100,"
+                + "\"stocks\":[" + String.join(",", stockJsonEntries) + "],\"errors\":[]}";
+        return new ObjectMapper().readValue(json, KrxOhlcvResponseDto.class);
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluatorTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluatorTest.java
@@ -1,0 +1,85 @@
+package com.example.demo.domain.volatility.util;
+
+import com.example.demo.domain.volatility.util.VolatilityAlertEvaluator.AlertResult;
+import com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator.IndicatorSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * volatility_detector/tests/test_indicators.py의 evaluate_alert 케이스를 이식 + 가중치 스코어 검증.
+ */
+class VolatilityAlertEvaluatorTest {
+
+    @Test
+    void 모든_조건_충족시_전체_reason과_만점_score() {
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                -6.0,   // abs >= 5
+                7.0,    // >= 5
+                30.0,
+                0.95,   // >= 0.9
+                10.0,
+                3.0,    // >= 2
+                0.85    // >= 0.8
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).containsExactlyInAnyOrder(
+                VolatilityAlertEvaluator.REASON_DAILY_RETURN,
+                VolatilityAlertEvaluator.REASON_INTRADAY_RANGE,
+                VolatilityAlertEvaluator.REASON_VOLUME_SPIKE,
+                VolatilityAlertEvaluator.REASON_BB_HIGH,
+                VolatilityAlertEvaluator.REASON_VOL20_QUANTILE
+        );
+        assertThat(result.alert()).isTrue();
+        // 0.15+0.25+0.20+0.10+0.30 = 1.0 (bb 가중치는 한 번만 반영)
+        assertThat(result.score()).isCloseTo(1.0, within(1e-9));
+    }
+
+    @Test
+    void 하단_밴드_조건만_충족() {
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                1.0,
+                1.0,
+                10.0,
+                0.05,  // <= 0.1
+                10.0,
+                1.0,
+                0.5
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).containsExactly(VolatilityAlertEvaluator.REASON_BB_LOW);
+        assertThat(result.alert()).isTrue();
+        assertThat(result.score()).isCloseTo(0.10, within(1e-9));
+    }
+
+    @Test
+    void NaN이면_아무_조건도_충족하지_않음() {
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).isEmpty();
+        assertThat(result.alert()).isFalse();
+        assertThat(result.score()).isZero();
+    }
+
+    @Test
+    void bb_상단_하단_동시충족은_불가능하지만_가중치는_한번만() {
+        // bb_percent_b가 상단(>=0.9) 조건만 만족하는 경우, 다른 조건 없이도 가중치 0.10만 반영되는지 확인
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                1.0, 1.0, 10.0, 0.95, 10.0, 1.0, 0.1
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).containsExactly(VolatilityAlertEvaluator.REASON_BB_HIGH);
+        assertThat(result.score()).isCloseTo(0.10, within(1e-9));
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
@@ -1,0 +1,103 @@
+package com.example.demo.domain.volatility.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * volatility_detector/tests/test_indicators.py의 대표 케이스를 이식한 유닛테스트.
+ */
+class VolatilityIndicatorCalculatorTest {
+
+    private static final double TOLERANCE = 1e-9;
+
+    @Test
+    void dailyReturnPct_계산() {
+        assertThat(VolatilityIndicatorCalculator.dailyReturnPct(new double[]{100.0, 105.0}))
+                .isCloseTo(5.0, within(TOLERANCE));
+
+        double expected = (99.0 - 105.0) / 105.0 * 100.0;
+        assertThat(VolatilityIndicatorCalculator.dailyReturnPct(new double[]{100.0, 105.0, 99.0}))
+                .isCloseTo(expected, within(TOLERANCE));
+    }
+
+    @Test
+    void intradayRangePct_계산() {
+        double expected = (110.0 - 100.0) / 105.0 * 100.0;
+        assertThat(VolatilityIndicatorCalculator.intradayRangePct(110.0, 100.0, 105.0))
+                .isCloseTo(expected, within(TOLERANCE));
+    }
+
+    @Test
+    void bollingerPercentB_및_width_계산() {
+        // 마지막 20개 종가 = 1..20 -> ma20=10.5, 표본표준편차=sqrt(35)
+        double[] close = new double[20];
+        for (int i = 0; i < 20; i++) {
+            close[i] = i + 1.0;
+        }
+
+        double std = Math.sqrt(35.0);
+        double upper = 10.5 + 2 * std;
+        double lower = 10.5 - 2 * std;
+        double expectedPb = (20.0 - lower) / (upper - lower);
+        double expectedWidth = (upper - lower) / 10.5 * 100.0;
+
+        assertThat(VolatilityIndicatorCalculator.bbPercentB(close)).isCloseTo(expectedPb, within(1e-6));
+        assertThat(VolatilityIndicatorCalculator.bbWidthPct(close)).isCloseTo(expectedWidth, within(1e-6));
+        assertThat(VolatilityIndicatorCalculator.bbPercentB(close)).isGreaterThanOrEqualTo(0.9);
+    }
+
+    @Test
+    void volumeSpikeRatio_계산() {
+        double[] volume = new double[20];
+        for (int i = 0; i < 19; i++) {
+            volume[i] = 100.0;
+        }
+        volume[19] = 300.0;
+
+        // rolling(20) mean = (100*19 + 300)/20 = 110
+        assertThat(VolatilityIndicatorCalculator.volumeSpikeRatio(volume))
+                .isCloseTo(300.0 / 110.0, within(TOLERANCE));
+    }
+
+    @Test
+    void percentileRank_극단값() {
+        double[] asc = {1.0, 2.0, 3.0, 4.0, 5.0};
+        double[] desc = {5.0, 4.0, 3.0, 2.0, 1.0};
+
+        assertThat(VolatilityIndicatorCalculator.percentileRank(asc, asc[asc.length - 1]))
+                .isCloseTo(1.0, within(TOLERANCE));
+        assertThat(VolatilityIndicatorCalculator.percentileRank(desc, desc[desc.length - 1]))
+                .isCloseTo(0.2, within(TOLERANCE));
+    }
+
+    @Test
+    void percentileRank_원소가_2개_미만이면_NaN() {
+        assertThat(VolatilityIndicatorCalculator.percentileRank(new double[]{3.0}, 3.0)).isNaN();
+    }
+
+    @Test
+    void calculate_전체_스냅샷_라운드트립() {
+        // 40일치 -> vol20 시계열이 2개 이상 나와 quantile이 정의됨
+        double[] close = new double[40];
+        for (int i = 0; i < 40; i++) {
+            close[i] = i + 1.0;
+        }
+
+        VolatilityIndicatorCalculator.IndicatorSnapshot snapshot =
+                VolatilityIndicatorCalculator.calculate(close, close, close, uniformVolume(40, 1000.0));
+
+        assertThat(snapshot.dailyReturnPct()).isNotNaN();
+        assertThat(snapshot.vol20Quantile()).isNotNaN();
+        assertThat(snapshot.vol20Quantile()).isBetween(0.0, 1.0);
+    }
+
+    private static double[] uniformVolume(int n, double value) {
+        double[] volume = new double[n];
+        for (int i = 0; i < n; i++) {
+            volume[i] = value;
+        }
+        return volume;
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
@@ -2,7 +2,9 @@ package com.example.demo.domain.volatility.util;
 
 import org.junit.jupiter.api.Test;
 
+import static com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator.MIN_VALID_TRADING_DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 /**
@@ -78,6 +80,26 @@ class VolatilityIndicatorCalculatorTest {
     }
 
     @Test
+    void percentileRank_NaN_혼합_시계열은_유효_관측치_기준으로_계산() {
+        // 유효 관측치 [1.0, 2.0] 중 2.0 → 1.0 (100th percentile)
+        assertThat(VolatilityIndicatorCalculator.percentileRank(new double[]{Double.NaN, 1.0, 2.0}, 2.0))
+                .isCloseTo(1.0, within(TOLERANCE));
+
+        // 유효 관측치 [1.0, 2.0, 3.0] 중 2.0 → 중간 순위
+        double expected = (1 + (1 + 1) / 2.0) / 3.0;
+        assertThat(VolatilityIndicatorCalculator.percentileRank(new double[]{Double.NaN, 1.0, 2.0, 3.0}, 2.0))
+                .isCloseTo(expected, within(TOLERANCE));
+    }
+
+    @Test
+    void percentileRank_유효_관측치_2개_미만이면_NaN() {
+        // NaN 제외 후 유효값 1개
+        assertThat(VolatilityIndicatorCalculator.percentileRank(new double[]{Double.NaN, 3.0}, 3.0)).isNaN();
+        // 전부 NaN
+        assertThat(VolatilityIndicatorCalculator.percentileRank(new double[]{Double.NaN, Double.NaN}, 1.0)).isNaN();
+    }
+
+    @Test
     void calculate_전체_스냅샷_라운드트립() {
         // 40일치 -> vol20 시계열이 2개 이상 나와 quantile이 정의됨
         double[] close = new double[40];
@@ -91,6 +113,42 @@ class VolatilityIndicatorCalculatorTest {
         assertThat(snapshot.dailyReturnPct()).isNotNaN();
         assertThat(snapshot.vol20Quantile()).isNotNaN();
         assertThat(snapshot.vol20Quantile()).isBetween(0.0, 1.0);
+    }
+
+    @Test
+    void calculate_20개_입력은_예외() {
+        double[] data = ascendingClose(20);
+        assertThatThrownBy(() ->
+                VolatilityIndicatorCalculator.calculate(data, data, data, uniformVolume(20, 1000.0)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void calculate_21개_입력은_예외() {
+        double[] data = ascendingClose(21);
+        assertThatThrownBy(() ->
+                VolatilityIndicatorCalculator.calculate(data, data, data, uniformVolume(21, 1000.0)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void calculate_22개_입력은_vol20Quantile이_유효() {
+        // MIN_VALID_TRADING_DAYS = 22: vol20Series 값 2개 → percentileRank 정의됨
+        assertThat(MIN_VALID_TRADING_DAYS).isEqualTo(22);
+        double[] data = ascendingClose(22);
+        VolatilityIndicatorCalculator.IndicatorSnapshot snapshot =
+                VolatilityIndicatorCalculator.calculate(data, data, data, uniformVolume(22, 1000.0));
+        assertThat(snapshot.vol20AnnualizedPct()).isNotNaN();
+        assertThat(snapshot.vol20Quantile()).isNotNaN();
+        assertThat(snapshot.vol20Quantile()).isBetween(0.0, 1.0);
+    }
+
+    private static double[] ascendingClose(int n) {
+        double[] close = new double[n];
+        for (int i = 0; i < n; i++) {
+            close[i] = i + 1.0;
+        }
+        return close;
     }
 
     private static double[] uniformVolume(int n, double value) {


### PR DESCRIPTION
## 💡 관련 이슈
- Close #33 

## 🛠 작업 내용
- AWS Lambda로 KRX api를 사용하여 ohlcv 지표를 가져오는 기능 구현
- 가져온 ohlcv 지표로 각 종목별 변동성을 계산하여 상위 10개의 변동성 종목 선정 기능 구현
- 선정된 변동성 종목들에 대한 리포트 생성 기능을 AWS Lambda를 사용하여 구현
- S3에 저장된 변동성 리포트를 이벤트 트리거를 통해 자동으로 DB에 저장하는 기능 구현


# 📸 결과 캡쳐화면
### [ 변동성 신호 탐지 ]
<img width="1815" height="407" alt="image" src="https://github.com/user-attachments/assets/c485cd07-016a-4199-a837-91ddc38d5049" />
<img width="1745" height="602" alt="image" src="https://github.com/user-attachments/assets/c0977fa6-6652-440d-bc28-6fc537762c97" />
<img width="807" height="207" alt="image" src="https://github.com/user-attachments/assets/525cfc3e-eca7-4714-8049-0bd8ae209ef5" />


### [ 변동성 리포트 생성 ]
<img width="1775" height="540" alt="image" src="https://github.com/user-attachments/assets/351208b9-2bb1-4fea-9b49-26cb48fe5cd7" />


### [ 변동성 리포트 저장 ]
<img width="1811" height="612" alt="image" src="https://github.com/user-attachments/assets/6cf292b4-e320-4a56-b7fb-1e9604ec08c5" />
<img width="831" height="20" alt="image" src="https://github.com/user-attachments/assets/ce0636aa-99d8-482f-ab72-c78ce096f397" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - KOSPI 시가총액 상위 종목의 변동성 탐지 및 분석 기능을 추가했습니다.
  - 변동성 종목 조회, 일괄·단일 리포트 생성, 리포트 완료 콜백 API를 제공합니다.
  - 탐지 결과의 성공·실패 건수와 실패 종목을 확인할 수 있습니다.
  - 외부 데이터 및 리포트 처리 연동과 콜백 보안을 지원합니다.

- **버그 수정**
  - 외부 API의 빈 응답과 오류를 구분해 처리하고, 검증 실패 메시지를 개선했습니다.
  - 리포트 콜백 요청의 인증 및 입력값 검증을 강화했습니다.

- **테스트**
  - 변동성 계산, 알림 평가, 종목 선별 및 데이터 저장 동작에 대한 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->