### PR TITLE
Feat/#40 refactor stock and volatility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ out/
 
 ### Application config ###
 #src/main/resources/application.yml
-
-### Test sources ###
-src/test/

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -51,6 +51,12 @@ public class KrxService {
             throw KrxHandler.krxLambdaResponseEmpty();
         }
 
+        // tradeDate는 동기화의 날짜 키다. 없으면 파싱 단계에서 NPE로 터지므로 여기서 계약 위반으로 막는다.
+        if (response.getTradeDate() == null || response.getTradeDate().isBlank()) {
+            log.error("KRX 코스피200 Lambda 응답에 tradeDate가 없습니다.");
+            throw KrxHandler.krxLambdaResponseParseError();
+        }
+
         if (response.getErrors() != null && !response.getErrors().isEmpty()) {
             log.warn("KRX 코스피200 Lambda가 {}건을 제외했습니다. 수신 {}건 / 구성종목 {}건. 사유={}",
                     response.getErrors().size(), response.getStocks().size(), response.getRequestedCount(),

--- a/src/main/java/com/example/demo/api/krx/service/KrxService.java
+++ b/src/main/java/com/example/demo/api/krx/service/KrxService.java
@@ -8,10 +8,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KrxService {
+
+    /**
+     * yyyyMMdd. STRICT 해석이라 20260231 같은 존재하지 않는 날짜를 보정하지 않고 거부한다.
+     * STRICT에서는 연도 필드로 yyyy(연호 기준) 대신 uuuu(proleptic)를 써야 한다.
+     */
+    private static final DateTimeFormatter TRADE_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuuMMdd").withResolverStyle(ResolverStyle.STRICT);
 
     private final KrxLambdaClient krxLambdaClient;
 
@@ -27,6 +39,10 @@ public class KrxService {
             throw KrxHandler.krxLambdaResponseEmpty();
         }
 
+        // 거래일은 탐지 결과의 날짜 키다. 값이 없거나 형식이 틀리면 뒤에서 서버 날짜로
+        // 대체되거나 파싱 예외가 500으로 새어 나가므로, 경계에서 계약 위반으로 막는다.
+        requireValidTradeDate(response.getEffectiveTradeDate(), "effective_trade_date");
+
         // Lambda가 종목별로 실패를 격리하고 errors에 사유를 담아 보낸다. 조용히 누락되지 않도록 남긴다.
         if (response.getErrors() != null && !response.getErrors().isEmpty()) {
             log.warn("KRX Lambda가 {}건을 제외했습니다. 수신 {}건 / 요청 {}건. 사유={}",
@@ -37,6 +53,23 @@ public class KrxService {
         }
 
         return response;
+    }
+
+    /**
+     * 거래일 문자열이 yyyyMMdd로 실재하는 날짜인지 확인한다.
+     * 파싱은 뒤 계층에서 다시 하지만, 그쪽 예외는 도메인 예외로 변환되지 않아 500이 된다.
+     */
+    private void requireValidTradeDate(String tradeDate, String fieldName) {
+        if (tradeDate == null || tradeDate.isBlank()) {
+            log.error("KRX Lambda 응답에 {}가 없습니다.", fieldName);
+            throw KrxHandler.krxLambdaResponseParseError();
+        }
+        try {
+            LocalDate.parse(tradeDate, TRADE_DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            log.error("KRX Lambda 응답의 {} 형식이 올바르지 않습니다. value={}", fieldName, tradeDate);
+            throw KrxHandler.krxLambdaResponseParseError();
+        }
     }
 
     /**
@@ -51,11 +84,9 @@ public class KrxService {
             throw KrxHandler.krxLambdaResponseEmpty();
         }
 
-        // tradeDate는 동기화의 날짜 키다. 없으면 파싱 단계에서 NPE로 터지므로 여기서 계약 위반으로 막는다.
-        if (response.getTradeDate() == null || response.getTradeDate().isBlank()) {
-            log.error("KRX 코스피200 Lambda 응답에 tradeDate가 없습니다.");
-            throw KrxHandler.krxLambdaResponseParseError();
-        }
+        // tradeDate는 동기화의 날짜 키다. 비어 있으면 NPE, 형식이 틀리면 DateTimeParseException이
+        // 그대로 500으로 새어 나가므로 여기서 계약 위반으로 막는다.
+        requireValidTradeDate(response.getTradeDate(), "tradeDate");
 
         if (response.getErrors() != null && !response.getErrors().isEmpty()) {
             log.warn("KRX 코스피200 Lambda가 {}건을 제외했습니다. 수신 {}건 / 구성종목 {}건. 사유={}",

--- a/src/main/java/com/example/demo/api/stock/controller/StockController.java
+++ b/src/main/java/com/example/demo/api/stock/controller/StockController.java
@@ -7,6 +7,8 @@ import com.example.demo.api.stock.service.StockUseCase;
 import com.example.demo.domain.stock.entity.Stock;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
 
 @Tag(name = "[주식] 주식 종목 API.")
 @Validated
@@ -29,8 +30,11 @@ public class StockController {
     @Operation(summary = "코스피200 종목·시세 동기화 (KRX)",
             description = "KRX Lambda로 코스피200 구성종목과 가장 가까운 거래일의 시가/종가를 한 번에 받아 반영합니다.<br>" +
                     "편출된 종목은 삭제하지 않고 비활성 처리하며, 재편입되면 다시 활성으로 되돌립니다.<br><br>" +
+                    "아래는 에러가 발생한 종목들입니다.<br>" +
                     "priceUnavailableStockCodes : 목록에는 반영됐지만 시세를 못 받은 종목(거래정지 등)<br>" +
-                    "unresolvedStockCodes : 종목명을 못 받아 목록에 반영하지 못한 종목(활성 상태 유지)")
+                    "unresolvedStockCodes : 종목명을 못 받아 목록에 반영하지 못한 종목(활성 상태 유지)<br>" +
+                    "priceUpdateSkippedStockCodes : 시세는 받았지만 DB에 반영하지 못한 종목. " +
+                    "이 목록이 비어 있지 않으면 동기화 정합성 이상 신호입니다.")
     @PostMapping("/sync")
     public ApiResponseDto<SyncStocksResponse> syncKospi200FromKrx() {
         return ApiResponseDto.onSuccess(stockUseCase.syncKospi200FromKrx());
@@ -49,12 +53,15 @@ public class StockController {
     @Operation(summary = "모든 종목 조회",
             description = "Stock에 저장된 종목을 페이지 단위로 조회합니다.<br>" +
                     "isActive=true : 코스피200에 현재 편입된 종목만<br>" +
-                    "isActive=false : 편입, 편출 전체 종목")
+                    "isActive=false : 편입, 편출 전체 종목<br>" +
+                    "pageSize는 1~200입니다.")
     @GetMapping("/all-stock")
     public ApiResponseDto<StockPageResponse> getAllStocks(
             @RequestParam(required = false) Boolean isActive,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int pageSize) {
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "20")
+            @Min(value = 1, message = "pageSize는 1 이상이어야 합니다.")
+            @Max(value = 200, message = "pageSize는 200 이하여야 합니다.") int pageSize) {
         Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.asc("stockCode")));
         Page<Stock> stockPage = stockUseCase.getAllStocks(isActive, pageable);
         return ApiResponseDto.onSuccess(StockConverter.toStockPageResponse(stockPage));

--- a/src/main/java/com/example/demo/api/stock/dto/StockResponseDto.java
+++ b/src/main/java/com/example/demo/api/stock/dto/StockResponseDto.java
@@ -32,6 +32,9 @@ public class StockResponseDto {
          * 종목 자체는 정상 편입 상태이며 시가·종가만 이전 값으로 남는다.
          */
         private List<String> priceUnavailableStockCodes;
+
+        // 시세는 받았지만 DB에 반영하지 못한 종목. 비어 있지 않으면 동기화 정합성 이상 신호다.
+        private List<String> priceUpdateSkippedStockCodes;
     }
 
     @Getter

--- a/src/main/java/com/example/demo/api/stock/dto/StockSyncResultDto.java
+++ b/src/main/java/com/example/demo/api/stock/dto/StockSyncResultDto.java
@@ -1,9 +1,0 @@
-package com.example.demo.api.stock.dto;
-
-public record StockSyncResultDto(
-        int addedCount,
-        int updatedCount,
-        int deactivatedCount,
-        int reactivatedCount
-) {
-}

--- a/src/main/java/com/example/demo/api/stock/mapper/StockConverter.java
+++ b/src/main/java/com/example/demo/api/stock/mapper/StockConverter.java
@@ -1,15 +1,70 @@
 package com.example.demo.api.stock.mapper;
 
+import com.example.demo.api.krx.dto.KrxKospi200ResponseDto;
 import com.example.demo.api.stock.dto.StockResponseDto.StockItemResponse;
 import com.example.demo.api.stock.dto.StockResponseDto.StockOpenAndClosePriceResponse;
 import com.example.demo.api.stock.dto.StockResponseDto.StockPageResponse;
+import com.example.demo.api.stock.dto.StockResponseDto.SyncStocksResponse;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
 import com.example.demo.domain.stock.entity.Stock;
+import com.example.demo.domain.stock.entity.StockPriceSnapshot;
+import com.example.demo.domain.stock.entity.StockSyncOutcome;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StockConverter {
+
+    /**
+     * KRX 응답을 동기화 입력으로 변환한다.
+     * 시세 유무는 errors가 아니라 응답 데이터(hasPrice)가 직접 말해주므로 그 기준으로 가른다.
+     */
+    public static Kospi200SyncCommand toKospi200SyncCommand(KrxKospi200ResponseDto response) {
+        Map<String, String> incomingStocks = response.getStocks().stream()
+                .collect(Collectors.toMap(
+                        KrxKospi200ResponseDto.StockPrice::getStockCode,
+                        KrxKospi200ResponseDto.StockPrice::getStockName));
+
+        List<KrxKospi200ResponseDto.ErrorItem> errors =
+                response.getErrors() == null ? List.of() : response.getErrors();
+        Set<String> errorCodes = errors.stream()
+                .map(KrxKospi200ResponseDto.ErrorItem::getStockCode)
+                .collect(Collectors.toSet());
+
+        List<StockPriceSnapshot> priceSnapshots = response.getStocks().stream()
+                .filter(KrxKospi200ResponseDto.StockPrice::hasPrice)
+                .map(s -> new StockPriceSnapshot(s.getStockCode(), s.getOpenPrice(), s.getClosePrice()))
+                .toList();
+
+        List<String> priceUnavailableStockCodes = response.getStocks().stream()
+                .filter(s -> !s.hasPrice())
+                .map(KrxKospi200ResponseDto.StockPrice::getStockCode)
+                .sorted()
+                .toList();
+
+        return new Kospi200SyncCommand(
+                LocalDate.parse(response.getTradeDate(), DateTimeFormatter.BASIC_ISO_DATE),
+                incomingStocks, errorCodes, priceSnapshots, priceUnavailableStockCodes);
+    }
+
+    public static SyncStocksResponse toSyncStocksResponse(Kospi200SyncCommand command, StockSyncOutcome outcome) {
+        return SyncStocksResponse.builder()
+                .tradeDate(command.tradeDate())
+                .addedCount(outcome.syncResult().addedCount())
+                .updatedCount(outcome.syncResult().updatedCount())
+                .deactivatedCount(outcome.syncResult().deactivatedCount())
+                .reactivatedCount(outcome.syncResult().reactivatedCount())
+                .priceUpdatedCount(outcome.priceUpdatedCount())
+                .unresolvedStockCodes(outcome.syncResult().unresolvedStockCodes())
+                .priceUnavailableStockCodes(command.priceUnavailableStockCodes())
+                .priceUpdateSkippedStockCodes(outcome.priceUpdateSkippedStockCodes())
+                .build();
+    }
 
     public static StockOpenAndClosePriceResponse toStockOpenAndClosePriceResponse(Stock stock) {
         return StockOpenAndClosePriceResponse.builder()

--- a/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
+++ b/src/main/java/com/example/demo/api/stock/service/StockUseCase.java
@@ -2,28 +2,20 @@ package com.example.demo.api.stock.service;
 
 import com.example.demo.api.krx.dto.KrxKospi200ResponseDto;
 import com.example.demo.api.krx.service.KrxService;
-import com.example.demo.api.stock.dto.StockResponseDto.*;
-import com.example.demo.api.stock.dto.StockSyncResultDto;
+import com.example.demo.api.stock.dto.StockResponseDto.StockOpenAndClosePriceResponse;
+import com.example.demo.api.stock.dto.StockResponseDto.SyncStocksResponse;
 import com.example.demo.api.stock.mapper.StockConverter;
 import com.example.demo.common.annotation.UseCase;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
 import com.example.demo.domain.stock.entity.Stock;
-import com.example.demo.domain.stock.entity.StockPriceSnapshot;
+import com.example.demo.domain.stock.entity.StockSyncOutcome;
 import com.example.demo.domain.stock.service.StockCommandService;
 import com.example.demo.domain.stock.service.StockQueryService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class StockUseCase {
@@ -32,60 +24,16 @@ public class StockUseCase {
     private final StockQueryService stockQueryService;
     private final KrxService krxService;
 
-    @Transactional
+    /**
+     * KRX 조회는 200종목 크롤링이라 수 분이 걸릴 수 있다. 트랜잭션 안에서 호출하면 그동안
+     * DB 커넥션을 붙잡게 되므로, 조회·변환은 트랜잭션 밖에서 끝내고 DB 쓰기만 커맨드에 맡긴다.
+     */
     public SyncStocksResponse syncKospi200FromKrx() {
         KrxKospi200ResponseDto response = krxService.getKospi200Prices();
-        LocalDate tradeDate = LocalDate.parse(response.getTradeDate(), DateTimeFormatter.BASIC_ISO_DATE);
+        Kospi200SyncCommand command = StockConverter.toKospi200SyncCommand(response);
+        StockSyncOutcome outcome = stockCommandService.syncStocksAndPrices(command);
 
-        // stocks에는 구성종목이 전부 들어온다. 시세를 못 받은 종목도 코드·이름은 있으므로
-        // 목록 동기화는 전체를 대상으로 하고, 시세 갱신만 가격이 있는 종목으로 좁힌다.
-        Map<String, String> codeToName = response.getStocks().stream()
-                .collect(Collectors.toMap(
-                        KrxKospi200ResponseDto.StockPrice::getStockCode,
-                        KrxKospi200ResponseDto.StockPrice::getStockName));
-
-        // errors에는 성격이 다른 둘이 섞여 온다. stocks에 있는지로 구분한다.
-        List<KrxKospi200ResponseDto.ErrorItem> errors =
-                response.getErrors() == null ? List.of() : response.getErrors();
-
-        // 종목명조차 못 받아 stocks에서 빠진 종목. 편출인지 알 수 없으므로 판정을 보류한다.
-        List<String> unresolvedStockCodes = errors.stream()
-                .map(KrxKospi200ResponseDto.ErrorItem::getStockCode)
-                .filter(code -> !codeToName.containsKey(code))
-                .distinct()
-                .toList();
-
-        // 목록에는 반영되지만 시세만 못 받은 종목(거래정지 등). 편출이 아니다.
-        List<String> priceUnavailableStockCodes = errors.stream()
-                .map(KrxKospi200ResponseDto.ErrorItem::getStockCode)
-                .filter(codeToName::containsKey)
-                .distinct()
-                .toList();
-
-        StockSyncResultDto syncResult =
-                stockCommandService.syncStocks(codeToName, Set.copyOf(unresolvedStockCodes));
-
-        List<StockPriceSnapshot> snapshots = response.getStocks().stream()
-                .filter(KrxKospi200ResponseDto.StockPrice::hasPrice)
-                .map(s -> new StockPriceSnapshot(s.getStockCode(), s.getOpenPrice(), s.getClosePrice()))
-                .toList();
-        int priceUpdatedCount = stockCommandService.updateStockPrices(snapshots, tradeDate);
-
-        log.info("코스피200 동기화 완료. tradeDate={} 신규={} 이름변경={} 편출={} 재편입={} 시세반영={} 시세미수신={} 미해결={}",
-                tradeDate, syncResult.addedCount(), syncResult.updatedCount(),
-                syncResult.deactivatedCount(), syncResult.reactivatedCount(), priceUpdatedCount,
-                priceUnavailableStockCodes.size(), unresolvedStockCodes.size());
-
-        return SyncStocksResponse.builder()
-                .tradeDate(tradeDate)
-                .addedCount(syncResult.addedCount())
-                .updatedCount(syncResult.updatedCount())
-                .deactivatedCount(syncResult.deactivatedCount())
-                .reactivatedCount(syncResult.reactivatedCount())
-                .priceUpdatedCount(priceUpdatedCount)
-                .unresolvedStockCodes(unresolvedStockCodes)
-                .priceUnavailableStockCodes(priceUnavailableStockCodes)
-                .build();
+        return StockConverter.toSyncStocksResponse(command, outcome);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
+++ b/src/main/java/com/example/demo/api/volatility/dto/VolatilityResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class VolatilityResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DetectionResult {
+        private LocalDate tradeDate;
         private List<DetectedStock> stocks;
         private int detectedCount;
     }
@@ -34,6 +36,7 @@ public class VolatilityResponseDto {
     @AllArgsConstructor
     public static class ReportGenerationResult {
         private String status;
+        private LocalDate tradeDate;
         private int requestedCount;
         private int successCount;
         private int failedCount;
@@ -47,6 +50,7 @@ public class VolatilityResponseDto {
     public static class VolatilityInfo {
         private String stockCode;
         private String stockName;
+        private LocalDate tradeDate;
         private String reportUrl;
         private LocalDateTime createdDate;
     }

--- a/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
+++ b/src/main/java/com/example/demo/api/volatility/mapper/VolatilityConverter.java
@@ -8,6 +8,7 @@ import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListR
 import com.example.demo.domain.volatility.entity.Volatility;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +16,7 @@ import static com.example.demo.common.consts.StaticVariable.*;
 
 public class VolatilityConverter {
 
-    public static DetectionResult toDetectionResult(List<VolatilitySignal> signals) {
+    public static DetectionResult toDetectionResult(List<VolatilitySignal> signals, LocalDate tradeDate) {
         List<DetectedStock> stocks = signals.stream()
                 .map(s -> DetectedStock.builder()
                         .stockCode(s.stockCode())
@@ -23,12 +24,14 @@ public class VolatilityConverter {
                         .build())
                 .collect(Collectors.toList());
         return DetectionResult.builder()
+                .tradeDate(tradeDate)
                 .stocks(stocks)
                 .detectedCount(stocks.size())
                 .build();
     }
 
-    public static ReportGenerationResult toReportGenerationResult(int requestedCount, List<String> failedStockCodes) {
+    public static ReportGenerationResult toReportGenerationResult(int requestedCount, List<String> failedStockCodes,
+                                                                 LocalDate tradeDate) {
         int failedCount = failedStockCodes.size();
         String status;
         if (failedCount == 0) {
@@ -41,6 +44,7 @@ public class VolatilityConverter {
 
         return ReportGenerationResult.builder()
                 .status(status)
+                .tradeDate(tradeDate)
                 .requestedCount(requestedCount)
                 .successCount(requestedCount - failedCount)
                 .failedCount(failedCount)
@@ -52,6 +56,7 @@ public class VolatilityConverter {
         return VolatilityInfo.builder()
                 .stockCode(volatility.getStockCode())
                 .stockName(volatility.getStockName())
+                .tradeDate(volatility.getTradeDate())
                 .reportUrl(volatility.getReportUrl())
                 .createdDate(volatility.getCreatedDate())
                 .build();

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +41,13 @@ public class VolatilityUseCase {
     private final VolatilityCommandService volatilityCommandService;
     private final ReportLambdaClient reportLambdaClient;
 
-    private static final DateTimeFormatter REPORT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    /**
+     * yyyyMMdd. 기본 SMART 해석은 20260231 같은 날짜를 2월 말로 보정해버려서,
+     * 콜백이 엉뚱한 거래일의 행을 갱신할 수 있다. STRICT로 거부한다.
+     * STRICT에서는 연도 필드로 yyyy(연호 기준) 대신 uuuu(proleptic)를 써야 한다.
+     */
+    private static final DateTimeFormatter REPORT_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuuMMdd").withResolverStyle(ResolverStyle.STRICT);
 
     /** KRX Lambda에 요청할 시총 상위 종목 수. */
     private static final int DETECTION_REQUEST_SIZE = 100;
@@ -102,9 +109,17 @@ public class VolatilityUseCase {
         return VolatilityConverter.toReportGenerationResult(targets.size(), failedStockCodes, tradeDate);
     }
 
+    /**
+     * 리포트 날짜는 저장된 거래일을 따라야 한다. 서버 날짜를 보내면 콜백이
+     * (stockCode, 그 날짜)로 행을 찾지 못해 리포트는 만들어졌는데 reportUrl이 비는 상태가 된다.
+     * 연결할 행이 없으면 애초에 생성하지 않는다. GPT 비용만 나가고 쓰이지 못한다.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void runSingleReportGeneration(SingleReportRequest request) {
-        String reportDate = LocalDate.now(SEOUL_ZONE).format(REPORT_DATE_FORMATTER);
-        invokeReportJob(reportDate, request.getStockCode(), request.getStockName(), request.getGptModel());
+        Volatility target = volatilityQueryService.getLatestByStockCode(request.getStockCode());
+        String reportDate = target.getTradeDate().format(REPORT_DATE_FORMATTER);
+
+        invokeReportJob(reportDate, target.getStockCode(), request.getStockName(), request.getGptModel());
     }
 
     private void invokeReportJob(String reportDate, String stockCode, String stockName, String gptModel) {

--- a/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
+++ b/src/main/java/com/example/demo/api/volatility/service/VolatilityUseCase.java
@@ -8,6 +8,7 @@ import com.example.demo.api.volatility.dto.VolatilityResponseDto.VolatilityListR
 import com.example.demo.api.volatility.mapper.VolatilityConverter;
 import com.example.demo.common.annotation.UseCase;
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.entity.VolatilityDetectionResult;
 import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
 import com.example.demo.domain.volatility.service.VolatilityDetectionService;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -28,6 +28,7 @@ import java.util.List;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportCallback;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.SingleReportRequest;
+import static com.example.demo.common.consts.StaticVariable.SEOUL_ZONE;
 
 @Slf4j
 @UseCase
@@ -41,34 +42,55 @@ public class VolatilityUseCase {
 
     private static final DateTimeFormatter REPORT_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    public DetectionResult runDetection() {
-        List<VolatilitySignal> signals = volatilityDetectionService.detect(100);
+    /** KRX Lambda에 요청할 시총 상위 종목 수. */
+    private static final int DETECTION_REQUEST_SIZE = 100;
+    /** 저장할 상위 변동성 종목 수. */
+    private static final int DETECTION_TOP_N = 10;
 
-        if (signals.isEmpty()) {
+    /**
+     * Lambda 호출이 수 분 걸리므로 트랜잭션 밖에서 실행한다.
+     * 저장은 VolatilityCommandService가 자체 트랜잭션으로 처리한다.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public DetectionResult runDetection() {
+        VolatilityDetectionResult detection = volatilityDetectionService.detect(DETECTION_REQUEST_SIZE);
+
+        if (detection.signals().isEmpty()) {
             log.error("변동성 분석 결과가 비어 있습니다. 전 종목이 스킵됐습니다.");
             throw VolatilityHandler.volatilityDetectionFailed();
         }
 
-        List<VolatilitySignal> top10 = volatilityDetectionService.selectTop(signals, 100, 10);
-        if (top10.isEmpty()) {
-            log.warn("변동성 알림이 탐지된 종목이 없습니다. 분석 종목 수={}", signals.size());
+        // 시총 가중치의 분모는 요청 수가 아니라 Lambda가 알려준 실제 유니버스 크기를 쓴다.
+        List<VolatilitySignal> topSignals = volatilityDetectionService.selectTop(
+                detection.signals(), detection.universeSize(), DETECTION_TOP_N);
+        if (topSignals.isEmpty()) {
+            log.warn("변동성 알림이 탐지된 종목이 없습니다. 분석 종목 수={}", detection.signals().size());
         }
 
-        volatilityCommandService.saveTopVolatilityStocks(top10);
-        return VolatilityConverter.toDetectionResult(top10);
+        volatilityCommandService.saveTopVolatilityStocks(topSignals, detection.tradeDate());
+        return VolatilityConverter.toDetectionResult(topSignals, detection.tradeDate());
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public ReportGenerationResult runReportGeneration(ReportGenerationRequest request) {
-        List<Volatility> todayVolatility = volatilityQueryService.getTodayVolatility();
-        if (todayVolatility.isEmpty()) {
+        List<Volatility> targets = volatilityQueryService.getLatestVolatility();
+        if (targets.isEmpty()) {
             throw VolatilityHandler.volatilityNotDetectedToday();
         }
 
-        String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
+        // 리포트 날짜는 탐지에 쓰인 거래일을 그대로 따른다. 서버 날짜를 쓰면 휴장일이나
+        // 자정 경계에서 콜백이 조회할 행과 어긋난다.
+        LocalDate tradeDate = targets.get(0).getTradeDate();
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        if (!tradeDate.isEqual(today)) {
+            log.warn("가장 최근 탐지 결과가 오늘이 아닙니다. 해당 거래일 기준으로 생성합니다. tradeDate={}, today={}",
+                    tradeDate, today);
+        }
+
+        String reportDate = tradeDate.format(REPORT_DATE_FORMATTER);
 
         List<String> failedStockCodes = new ArrayList<>();
-        for (Volatility v : todayVolatility) {
+        for (Volatility v : targets) {
             try {
                 invokeReportJob(reportDate, v.getStockCode(), v.getStockName(), request.getGptModel());
             } catch (Exception e) {
@@ -77,11 +99,11 @@ public class VolatilityUseCase {
             }
         }
 
-        return VolatilityConverter.toReportGenerationResult(todayVolatility.size(), failedStockCodes);
+        return VolatilityConverter.toReportGenerationResult(targets.size(), failedStockCodes, tradeDate);
     }
 
     public void runSingleReportGeneration(SingleReportRequest request) {
-        String reportDate = LocalDate.now().format(REPORT_DATE_FORMATTER);
+        String reportDate = LocalDate.now(SEOUL_ZONE).format(REPORT_DATE_FORMATTER);
         invokeReportJob(reportDate, request.getStockCode(), request.getStockName(), request.getGptModel());
     }
 
@@ -93,25 +115,35 @@ public class VolatilityUseCase {
                 .stockName(stockName)
                 .reportDate(reportDate)
                 .triggerType("VOLATILITY")
-                .gptModel(gptModel)
+                .gptModel(normalizeGptModel(gptModel))
                 .build());
     }
 
+    /**
+     * Lambda는 gptModel 키가 있으면 비어 있지 않은 문자열이어야 한다고 검증한다.
+     * 빈 문자열은 @JsonInclude(NON_NULL)에 걸리지 않고 그대로 나가 Lambda 실행 오류가 되므로,
+     * 공백이면 null로 바꿔 키 자체가 빠지게 한다. 그러면 Lambda가 기본 모델을 쓴다.
+     */
+    private String normalizeGptModel(String gptModel) {
+        if (gptModel == null || gptModel.isBlank()) {
+            return null;
+        }
+        return gptModel.trim();
+    }
+
     public void handleReportCallback(ReportCallback request) {
-        LocalDate reportDate;
+        LocalDate tradeDate;
         try {
-            reportDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
+            tradeDate = LocalDate.parse(request.getReportDate(), REPORT_DATE_FORMATTER);
         } catch (DateTimeParseException e) {
             throw VolatilityHandler.reportCallbackInvalidRequest();
         }
-        volatilityCommandService.updateReportUrl(request.getStockCode(), reportDate, request.getReportUrl());
+        volatilityCommandService.updateReportUrl(request.getStockCode(), tradeDate, request.getReportUrl());
     }
 
     @Transactional(readOnly = true)
     public VolatilityListResponse getAllVolatilityByDate(LocalDate date) {
-        LocalDateTime start = date.atStartOfDay();
-        LocalDateTime end = date.plusDays(1).atStartOfDay();
-        return VolatilityConverter.toVolatilityListResponse(volatilityQueryService.getAllVolatilityByDate(start, end));
+        return VolatilityConverter.toVolatilityListResponse(volatilityQueryService.getByTradeDate(date));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/domain/stock/entity/Kospi200SyncCommand.java
+++ b/src/main/java/com/example/demo/domain/stock/entity/Kospi200SyncCommand.java
@@ -1,0 +1,25 @@
+package com.example.demo.domain.stock.entity;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * KRX 응답을 동기화에 필요한 형태로만 추린 것.
+ * 외부 응답 DTO를 그대로 도메인까지 끌고 가지 않도록 경계에서 한 번 변환한다.
+ *
+ * @param incomingStocks             이번 구성종목 코드→이름
+ * @param errorCodes                 Lambda가 데이터를 못 받았다고 보고한 코드.
+ *                                   목록에서 빠진 종목이 이탈인지 일시적 실패인지 가를 때 쓴다.
+ * @param priceSnapshots             시가·종가를 받은 종목
+ * @param priceUnavailableStockCodes 목록에는 있으나 시가·종가가 비어 온 종목
+ */
+public record Kospi200SyncCommand(
+        LocalDate tradeDate,
+        Map<String, String> incomingStocks,
+        Set<String> errorCodes,
+        List<StockPriceSnapshot> priceSnapshots,
+        List<String> priceUnavailableStockCodes
+) {
+}

--- a/src/main/java/com/example/demo/domain/stock/entity/StockPriceUpdateResult.java
+++ b/src/main/java/com/example/demo/domain/stock/entity/StockPriceUpdateResult.java
@@ -1,0 +1,15 @@
+package com.example.demo.domain.stock.entity;
+
+import java.util.List;
+
+/**
+ * 시세 갱신 결과.
+ * 반영 건수만 돌려주면 "몇 건이 왜 빠졌는지"를 알 수 없어, 반영하지 못한 종목 코드를 함께 남긴다.
+ * 같은 실행에서 목록 동기화가 끝난 뒤라 DB에 없거나 비활성인 종목이 나오는 것은
+ * 단순 누락이 아니라 동기화 정합성 이상 신호다.
+ */
+public record StockPriceUpdateResult(
+        int updatedCount,
+        List<String> skippedStockCodes
+) {
+}

--- a/src/main/java/com/example/demo/domain/stock/entity/StockSyncOutcome.java
+++ b/src/main/java/com/example/demo/domain/stock/entity/StockSyncOutcome.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.stock.entity;
+
+
+import java.util.List;
+
+/** 목록 동기화와 시세 갱신을 한 트랜잭션으로 묶어 실행한 결과. */
+public record StockSyncOutcome(
+        StockSyncResult syncResult,
+        int priceUpdatedCount,
+        List<String> priceUpdateSkippedStockCodes
+) {
+}

--- a/src/main/java/com/example/demo/domain/stock/entity/StockSyncResult.java
+++ b/src/main/java/com/example/demo/domain/stock/entity/StockSyncResult.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.stock.entity;
+
+import java.util.List;
+
+/** 목록 동기화 결과. 세 갈래 판정이 각각 몇 건이었는지와, 판정을 보류한 종목. */
+public record StockSyncResult(
+        int addedCount,
+        int updatedCount,
+        int deactivatedCount,
+        int reactivatedCount,
+        /** DB에는 활성으로 있는데 이번 응답에 안 와서, 이탈인지 알 수 없어 상태를 그대로 둔 종목. */
+        List<String> unresolvedStockCodes
+) {
+}

--- a/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
@@ -15,9 +15,7 @@ import java.util.Objects;
 public enum StockErrorStatus implements BaseErrorCode {
 
     //  Entity Stock(4250~4299)
-    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4250, "stock을 찾지 못 했습니다."),
-    /** S3Service와 짝을 이루는 코드. 현재 던지는 곳은 없으나 S3 인프라를 유지하므로 함께 남긴다. */
-    S3_FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4251, "S3 파일 처리 중 오류가 발생했습니다.");
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4250, "stock을 찾지 못 했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockErrorStatus.java
@@ -15,7 +15,11 @@ import java.util.Objects;
 public enum StockErrorStatus implements BaseErrorCode {
 
     //  Entity Stock(4250~4299)
-    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4250, "stock을 찾지 못 했습니다.");
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, 4250, "stock을 찾지 못 했습니다."),
+    @ExplainError("지수 구성종목 목록이 일부만 조회되면 나머지가 통째로 편출됩니다. "
+            + "KRX Lambda 응답의 구성종목 수를 먼저 확인하세요.")
+    STOCK_ABNORMAL_DEACTIVATION(HttpStatus.BAD_GATEWAY, 4251,
+            "편출 판정 종목이 비정상적으로 많아 동기화를 중단했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
@@ -12,4 +12,8 @@ public class StockHandler extends GeneralException {
     public static StockHandler notFound() {
         return new StockHandler(StockErrorStatus.STOCK_NOT_FOUND);
     }
+
+    public static StockHandler abnormalDeactivation() {
+        return new StockHandler(StockErrorStatus.STOCK_ABNORMAL_DEACTIVATION);
+    }
 }

--- a/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
+++ b/src/main/java/com/example/demo/domain/stock/exception/StockHandler.java
@@ -12,8 +12,4 @@ public class StockHandler extends GeneralException {
     public static StockHandler notFound() {
         return new StockHandler(StockErrorStatus.STOCK_NOT_FOUND);
     }
-
-    public static StockHandler s3FileIoError() {
-        return new StockHandler(StockErrorStatus.S3_FILE_IO_ERROR);
-    }
 }

--- a/src/main/java/com/example/demo/domain/stock/repository/StockRepository.java
+++ b/src/main/java/com/example/demo/domain/stock/repository/StockRepository.java
@@ -11,8 +11,6 @@ import java.util.Optional;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
     Optional<Stock> findByStockCode(String stockCode);
-    /** 시세 갱신 대상. 편출된 종목은 더 이상 시세를 받지 않으므로 활성 종목만 조회한다. */
     List<Stock> findAllByStockCodeInAndIsActiveTrue(Collection<String> stockCodes);
     Page<Stock> findAllByIsActive(Boolean isActive, Pageable pageable);
-    List<Stock> findAllByIsActive(Boolean isActive);
 }

--- a/src/main/java/com/example/demo/domain/stock/service/StockCommandService.java
+++ b/src/main/java/com/example/demo/domain/stock/service/StockCommandService.java
@@ -1,7 +1,10 @@
 package com.example.demo.domain.stock.service;
 
-import com.example.demo.api.stock.dto.StockSyncResultDto;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
 import com.example.demo.domain.stock.entity.StockPriceSnapshot;
+import com.example.demo.domain.stock.entity.StockPriceUpdateResult;
+import com.example.demo.domain.stock.entity.StockSyncResult;
+import com.example.demo.domain.stock.entity.StockSyncOutcome;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,11 +14,19 @@ import java.util.Set;
 public interface StockCommandService {
     /**
      * @param sourceStocks    현재 구성종목 코드→이름
-     * @param unresolvedCodes 구성종목이지만 이번에 데이터를 못 받은 코드.
-     *                        편출인지 일시적 실패인지 알 수 없으므로 활성 상태를 건드리지 않는다.
+     * @param errorCodes Lambda가 데이터를 못 받았다고 보고한 코드 전체.
+     *                   이 중 DB에는 있는데 이번 목록에 없는 종목만 편출 판정을 보류한다.
+     *                   어떤 종목이 그에 해당하는지는 DB와 비교해야 알 수 있으므로 여기서 가른다.
      */
-    StockSyncResultDto syncStocks(Map<String, String> sourceStocks, Set<String> unresolvedCodes);
+    StockSyncResult syncStocks(Map<String, String> sourceStocks, Set<String> errorCodes);
 
-    /** 여러 종목의 시세를 한 번에 갱신하고 실제 반영된 건수를 돌려준다. */
-    int updateStockPrices(List<StockPriceSnapshot> snapshots, LocalDate tradeDate);
+    /** 여러 종목의 시세를 한 번에 갱신하고, 반영 건수와 반영하지 못한 종목 코드를 돌려준다. */
+    StockPriceUpdateResult updateStockPrices(List<StockPriceSnapshot> snapshots, LocalDate tradeDate);
+
+    /**
+     * 목록 동기화와 시세 갱신을 한 트랜잭션으로 묶어 실행한다.
+     * KRX Lambda 호출은 수 분이 걸릴 수 있어 이 메서드 밖에서 끝내고 결과만 넘긴다.
+     * 트랜잭션이 DB 쓰기 구간만 감싸게 하면서, 두 작업의 원자성은 그대로 유지하기 위한 진입점이다.
+     */
+    StockSyncOutcome syncStocksAndPrices(Kospi200SyncCommand command);
 }

--- a/src/main/java/com/example/demo/domain/stock/service/StockCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/stock/service/StockCommandServiceImpl.java
@@ -1,8 +1,11 @@
 package com.example.demo.domain.stock.service;
 
-import com.example.demo.api.stock.dto.StockSyncResultDto;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
 import com.example.demo.domain.stock.entity.Stock;
+import com.example.demo.domain.stock.entity.StockSyncResult;
 import com.example.demo.domain.stock.entity.StockPriceSnapshot;
+import com.example.demo.domain.stock.entity.StockPriceUpdateResult;
+import com.example.demo.domain.stock.entity.StockSyncOutcome;
 import com.example.demo.domain.stock.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,14 +29,35 @@ public class StockCommandServiceImpl implements StockCommandService {
     private final StockRepository stockRepository;
 
     /**
+     * 두 작업을 한 트랜잭션 안에서 순서대로 실행한다.
+     * 같은 빈 안에서의 호출이라 프록시를 타지 않지만, 전파 속성이 REQUIRED라
+     * 어차피 이 메서드의 트랜잭션에 합류했을 동작과 동일하다.
+     */
+    @Override
+    public StockSyncOutcome syncStocksAndPrices(Kospi200SyncCommand command) {
+        StockSyncResult syncResult = syncStocks(command.incomingStocks(), command.errorCodes());
+        StockPriceUpdateResult priceResult = updateStockPrices(command.priceSnapshots(), command.tradeDate());
+
+        log.info("코스피200 동기화 완료. tradeDate={} 구성종목={} 신규={} 이름변경={} 이탈={} 재편입={} "
+                        + "시세반영={} 시세미수신={} 반영실패={} 판정보류={}",
+                command.tradeDate(), command.incomingStocks().size(),
+                syncResult.addedCount(), syncResult.updatedCount(),
+                syncResult.deactivatedCount(), syncResult.reactivatedCount(),
+                priceResult.updatedCount(), command.priceUnavailableStockCodes().size(),
+                priceResult.skippedStockCodes().size(), syncResult.unresolvedStockCodes().size());
+
+        return new StockSyncOutcome(syncResult, priceResult.updatedCount(), priceResult.skippedStockCodes());
+    }
+
+    /**
      * 코스피200에 편입된(활성) 종목의 시세만 갱신한다.
      * 종목별로 findByStockCode를 반복하면 200번 조회가 나가므로 한 번에 읽어 메모리에서 갱신하며,
      * 변경 감지로 flush된다. DB에 없거나 편출된 종목은 건너뛴다.
      */
     @Override
-    public int updateStockPrices(List<StockPriceSnapshot> snapshots, LocalDate tradeDate) {
+    public StockPriceUpdateResult updateStockPrices(List<StockPriceSnapshot> snapshots, LocalDate tradeDate) {
         if (snapshots.isEmpty()) {
-            return 0;
+            return new StockPriceUpdateResult(0, List.of());
         }
 
         Map<String, StockPriceSnapshot> byCode = snapshots.stream()
@@ -40,41 +65,64 @@ public class StockCommandServiceImpl implements StockCommandService {
 
         List<Stock> stocks = stockRepository.findAllByStockCodeInAndIsActiveTrue(byCode.keySet());
 
+        Set<String> appliedCodes = new HashSet<>();
         for (Stock stock : stocks) {
             StockPriceSnapshot snapshot = byCode.get(stock.getStockCode());
             stock.updatePrice(snapshot.openPrice(), snapshot.closePrice(), tradeDate);
+            appliedCodes.add(stock.getStockCode());
         }
 
-        int skipped = byCode.size() - stocks.size();
-        if (skipped > 0) {
-            log.warn("시세를 반영하지 못한 종목 {}건. DB에 없거나 비활성 종목입니다.", skipped);
+        // 어떤 종목이 빠졌는지 남긴다. 같은 실행에서 목록 동기화를 끝낸 뒤라
+        // 여기서 빠지는 종목이 있으면 단순 누락이 아니라 동기화 정합성 이상 신호다.
+        List<String> skippedStockCodes = byCode.keySet().stream()
+                .filter(code -> !appliedCodes.contains(code))
+                .sorted()
+                .toList();
+
+        if (!skippedStockCodes.isEmpty()) {
+            log.warn("시세를 반영하지 못한 종목 {}건. DB에 없거나 비활성 종목입니다. codes={}",
+                    skippedStockCodes.size(), skippedStockCodes);
         }
 
-        return stocks.size();
+        return new StockPriceUpdateResult(appliedCodes.size(), skippedStockCodes);
     }
 
+    /**
+     * 3~6단계. 응답 목록과 DB 목록을 비교해 세 갈래로 가른 뒤 각각 반영한다.
+     * 판정(무엇이 어느 갈래인가)과 반영(무엇을 할 것인가)을 분리해야, 결과만 보고도 왜 그렇게 됐는지 읽힌다.
+     */
     @Override
-    public StockSyncResultDto syncStocks(Map<String, String> sourceStocks, Set<String> unresolvedCodes) {
-        List<Stock> dbStocks = stockRepository.findAll();
-        Map<String, Stock> byCode = dbStocks.stream()
+    public StockSyncResult syncStocks(Map<String, String> incomingStocks, Set<String> errorCodes) {
+        // 3. 현재 저장된 종목
+        Map<String, Stock> stored = stockRepository.findAll().stream()
                 .collect(Collectors.toMap(Stock::getStockCode, stock -> stock));
 
-        List<Stock> toInsert = new ArrayList<>();
+        Set<String> incomingCodes = incomingStocks.keySet();
+
+        // 4~5. 세 갈래로 분류
+        //  ① 유지 : 응답에도 있고 DB에도 있는 종목
+        //  ② 신규 : 응답에 있고 DB에 없는 종목 (이번에 코스피200 편입)
+        //  ③ 이탈 : DB에 활성으로 있는데 응답에 없는 종목 (이번에 코스피200 이탈)
+        List<String> retainedCodes = incomingCodes.stream()
+                .filter(stored::containsKey)
+                .sorted()
+                .toList();
+        List<String> newCodes = incomingCodes.stream()
+                .filter(code -> !stored.containsKey(code))
+                .sorted()
+                .toList();
+        List<String> droppedCodes = stored.keySet().stream()
+                .filter(code -> !incomingCodes.contains(code))
+                .filter(code -> Boolean.TRUE.equals(stored.get(code).getIsActive()))
+                .sorted()
+                .toList();
+
+        // 6-①. 유지 종목은 이름 변경과 재활성만 반영한다. 변경 감지로 flush된다.
         int updatedCount = 0;
         int reactivatedCount = 0;
-
-        for (Map.Entry<String, String> entry : sourceStocks.entrySet()) {
-            String stockCode = entry.getKey();
-            String stockName = entry.getValue();
-            Stock stock = byCode.get(stockCode);
-
-            if (stock == null) {
-                toInsert.add(Stock.builder()
-                        .stockCode(stockCode)
-                        .stockName(stockName)
-                        .build());
-                continue;
-            }
+        for (String stockCode : retainedCodes) {
+            Stock stock = stored.get(stockCode);
+            String stockName = incomingStocks.get(stockCode);
 
             if (!stockName.equals(stock.getStockName())) {
                 stock.updateName(stockName);
@@ -87,31 +135,40 @@ public class StockCommandServiceImpl implements StockCommandService {
             }
         }
 
+        // 6-②. 신규 종목은 한 번에 저장한다.
+        List<Stock> toInsert = new ArrayList<>();
+        for (String stockCode : newCodes) {
+            toInsert.add(Stock.builder()
+                    .stockCode(stockCode)
+                    .stockName(incomingStocks.get(stockCode))
+                    .build());
+        }
+        if (!toInsert.isEmpty()) {
+            stockRepository.saveAll(toInsert);
+        }
+
+        // 6-③. 이탈 종목은 삭제하지 않고 비활성 처리한다.
+        //      단, Lambda가 데이터를 못 받았다고 보고한 종목은 이탈인지 일시적 실패인지 알 수 없다.
+        //      거래정지 종목을 편출로 오판하면 목록에서 사라지므로, 이번 회차는 상태를 그대로 둔다.
         int deactivatedCount = 0;
-        for (Stock stock : dbStocks) {
-            String stockCode = stock.getStockCode();
+        List<String> unresolvedStockCodes = new ArrayList<>();
+        for (String stockCode : droppedCodes) {
+            Stock stock = stored.get(stockCode);
 
-            if (sourceStocks.containsKey(stockCode) || !Boolean.TRUE.equals(stock.getIsActive())) {
-                continue;
-            }
-
-            // 구성종목이지만 시세를 못 받은 종목이다. 거래정지처럼 일시적인 경우가 많아
-            // 편출로 단정하면 안 된다. 이번 회차는 상태를 그대로 둔다.
-            if (unresolvedCodes.contains(stockCode)) {
-                log.info("시세 미수신으로 편출 판정 보류. stockCode={}, stockName={}",
+            if (errorCodes.contains(stockCode)) {
+                log.info("데이터 미수신으로 이탈 판정 보류. stockCode={}, stockName={}",
                         stockCode, stock.getStockName());
+                unresolvedStockCodes.add(stockCode);
                 continue;
             }
 
             stock.deactivate();
             deactivatedCount++;
-            log.info("종목 편출. stockCode={}, stockName={}", stockCode, stock.getStockName());
+            log.info("종목 이탈. stockCode={}, stockName={}", stockCode, stock.getStockName());
         }
 
-        if (!toInsert.isEmpty()) {
-            stockRepository.saveAll(toInsert);
-        }
-
-        return new StockSyncResultDto(toInsert.size(), updatedCount, deactivatedCount, reactivatedCount);
+        // 7. 결과
+        return new StockSyncResult(
+                toInsert.size(), updatedCount, deactivatedCount, reactivatedCount, unresolvedStockCodes);
     }
 }

--- a/src/main/java/com/example/demo/domain/stock/service/StockCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/stock/service/StockCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.domain.stock.service;
 
 import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
 import com.example.demo.domain.stock.entity.Stock;
+import com.example.demo.domain.stock.exception.StockHandler;
 import com.example.demo.domain.stock.entity.StockSyncResult;
 import com.example.demo.domain.stock.entity.StockPriceSnapshot;
 import com.example.demo.domain.stock.entity.StockPriceUpdateResult;
@@ -25,6 +26,15 @@ import java.util.stream.Collectors;
 @Transactional
 @RequiredArgsConstructor
 public class StockCommandServiceImpl implements StockCommandService {
+
+    /**
+     * 한 번에 이만큼 넘게 편출 판정이 나오면 데이터 이상으로 보고 막는다.
+     * 코스피200 정기변경은 연 2회, 보통 3~10종목이라 정상 운영에서는 걸리지 않는다.
+     * 지수 구성종목 목록이 일부만 조회되면 빠진 종목이 전부 편출로 판정되는데,
+     * "목록이 비었을 때"만 막는 기존 가드로는 이 경우를 못 잡는다.
+     */
+    private static final int DEACTIVATION_LIMIT_COUNT = 20;
+    private static final double DEACTIVATION_LIMIT_RATIO = 0.1;
 
     private final StockRepository stockRepository;
 
@@ -85,6 +95,24 @@ public class StockCommandServiceImpl implements StockCommandService {
         }
 
         return new StockPriceUpdateResult(appliedCodes.size(), skippedStockCodes);
+    }
+
+    /**
+     * 편출 규모가 정상 범위인지 확인한다.
+     * 지수 구성종목 목록이 일부만 조회되면 빠진 종목이 전부 편출로 판정되므로,
+     * 반영 전에 막아 트랜잭션을 되돌린다.
+     */
+    private void verifyDeactivationScale(Map<String, Stock> stored, List<String> toDeactivate) {
+        long activeCount = stored.values().stream()
+                .filter(stock -> Boolean.TRUE.equals(stock.getIsActive()))
+                .count();
+
+        if (toDeactivate.size() > DEACTIVATION_LIMIT_COUNT
+                && toDeactivate.size() > activeCount * DEACTIVATION_LIMIT_RATIO) {
+            log.error("편출 판정이 비정상적으로 많아 동기화를 중단합니다. 활성={} 편출대상={} codes={}",
+                    activeCount, toDeactivate.size(), toDeactivate);
+            throw StockHandler.abnormalDeactivation();
+        }
     }
 
     /**
@@ -150,22 +178,25 @@ public class StockCommandServiceImpl implements StockCommandService {
         // 6-③. 이탈 종목은 삭제하지 않고 비활성 처리한다.
         //      단, Lambda가 데이터를 못 받았다고 보고한 종목은 이탈인지 일시적 실패인지 알 수 없다.
         //      거래정지 종목을 편출로 오판하면 목록에서 사라지므로, 이번 회차는 상태를 그대로 둔다.
-        int deactivatedCount = 0;
-        List<String> unresolvedStockCodes = new ArrayList<>();
-        for (String stockCode : droppedCodes) {
+        List<String> unresolvedStockCodes = droppedCodes.stream()
+                .filter(errorCodes::contains)
+                .toList();
+        List<String> toDeactivate = droppedCodes.stream()
+                .filter(code -> !errorCodes.contains(code))
+                .toList();
+
+        verifyDeactivationScale(stored, toDeactivate);
+
+        for (String stockCode : unresolvedStockCodes) {
+            log.info("데이터 미수신으로 이탈 판정 보류. stockCode={}, stockName={}",
+                    stockCode, stored.get(stockCode).getStockName());
+        }
+        for (String stockCode : toDeactivate) {
             Stock stock = stored.get(stockCode);
-
-            if (errorCodes.contains(stockCode)) {
-                log.info("데이터 미수신으로 이탈 판정 보류. stockCode={}, stockName={}",
-                        stockCode, stock.getStockName());
-                unresolvedStockCodes.add(stockCode);
-                continue;
-            }
-
             stock.deactivate();
-            deactivatedCount++;
             log.info("종목 이탈. stockCode={}, stockName={}", stockCode, stock.getStockName());
         }
+        int deactivatedCount = toDeactivate.size();
 
         // 7. 결과
         return new StockSyncResult(

--- a/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/Volatility.java
@@ -7,8 +7,16 @@ import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
+
 @Entity
-@Table(name = "volatility")
+@Table(
+        name = "volatility",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_volatility_stock_code_trade_date",
+                columnNames = {"stock_code", "trade_date"}),
+        indexes = @Index(name = "idx_volatility_trade_date", columnList = "trade_date")
+)
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,10 +35,21 @@ public class Volatility extends BaseTimeEntity {
     @Column(name = "stock_code", nullable = false, length = 20)
     private String stockCode;
 
+    /**
+     * KRX 응답의 실제 거래일. createdDate(서버 시각)를 날짜 키로 쓰면 타임존·자정 경계에서
+     * 저장 날짜와 실제 거래일이 어긋나므로, 날짜 조회는 모두 이 컬럼을 기준으로 한다.
+     */
+    @Column(name = "trade_date", nullable = false)
+    private LocalDate tradeDate;
+
     @Column(name = "report_url")
     private String reportUrl;
 
     public void updateReportUrl(String reportUrl) {
         this.reportUrl = reportUrl;
+    }
+
+    public void updateStockName(String stockName) {
+        this.stockName = stockName;
     }
 }

--- a/src/main/java/com/example/demo/domain/volatility/entity/VolatilityDetectionResult.java
+++ b/src/main/java/com/example/demo/domain/volatility/entity/VolatilityDetectionResult.java
@@ -1,0 +1,16 @@
+package com.example.demo.domain.volatility.entity;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 변동성 탐지 1회의 결과.
+ * 거래일과 유니버스 크기를 KRX 응답에서 그대로 실어와, 저장 날짜가 서버 시각에,
+ * 시총 가중치의 분모가 하드코딩 상수에 의존하지 않게 한다.
+ */
+public record VolatilityDetectionResult(
+        LocalDate tradeDate,
+        int universeSize,
+        List<VolatilitySignal> signals
+) {
+}

--- a/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
+++ b/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
@@ -2,20 +2,19 @@ package com.example.demo.domain.volatility.repository;
 
 import com.example.demo.domain.volatility.entity.Volatility;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface VolatilityRepository extends JpaRepository<Volatility, Long> {
-    List<Volatility> findAllByStockCodeOrderByCreatedDateDesc(String stockCode);
-    List<Volatility> findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(LocalDateTime start, LocalDateTime end);
-    Optional<Volatility> findFirstByStockCodeAndCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(String stockCode, LocalDateTime start, LocalDateTime end);
+    List<Volatility> findAllByStockCodeOrderByTradeDateDesc(String stockCode);
 
-    @Modifying
-    @Query("DELETE FROM Volatility v WHERE v.createdDate >= :start AND v.createdDate < :end")
-    void deleteAllByCreatedDateBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+    List<Volatility> findAllByTradeDateOrderByIdAsc(LocalDate tradeDate);
+
+    /** (stock_code, trade_date) 유니크 제약이 있으므로 최대 1건이다. */
+    Optional<Volatility> findByStockCodeAndTradeDate(String stockCode, LocalDate tradeDate);
+
+    /** 탐지 기록이 있는 가장 최근 거래일을 찾기 위한 조회. 리포트 생성 대상을 정할 때 쓴다. */
+    Optional<Volatility> findFirstByOrderByTradeDateDesc();
 }

--- a/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
+++ b/src/main/java/com/example/demo/domain/volatility/repository/VolatilityRepository.java
@@ -1,7 +1,11 @@
 package com.example.demo.domain.volatility.repository;
 
 import com.example.demo.domain.volatility.entity.Volatility;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,7 +14,18 @@ import java.util.Optional;
 public interface VolatilityRepository extends JpaRepository<Volatility, Long> {
     List<Volatility> findAllByStockCodeOrderByTradeDateDesc(String stockCode);
 
+    Optional<Volatility> findFirstByStockCodeOrderByTradeDateDesc(String stockCode);
+
     List<Volatility> findAllByTradeDateOrderByIdAsc(LocalDate tradeDate);
+
+    /**
+     * 저장 경로 전용. 같은 거래일에 대한 동시 탐지가 서로의 스냅샷을 못 보고
+     * 삭제·삽입을 교차시키면 최종 집합이 어느 쪽 결과와도 달라진다.
+     * 해당 거래일의 행을 잠가 회차 단위로 직렬화한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT v FROM Volatility v WHERE v.tradeDate = :tradeDate ORDER BY v.id ASC")
+    List<Volatility> findAllByTradeDateForUpdate(@Param("tradeDate") LocalDate tradeDate);
 
     /** (stock_code, trade_date) 유니크 제약이 있으므로 최대 1건이다. */
     Optional<Volatility> findByStockCodeAndTradeDate(String stockCode, LocalDate tradeDate);

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandService.java
@@ -6,6 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface VolatilityCommandService {
-    void saveTopVolatilityStocks(List<VolatilitySignal> topSignals);
-    void updateReportUrl(String stockCode, LocalDate reportDate, String reportUrl);
+    void saveTopVolatilityStocks(List<VolatilitySignal> topSignals, LocalDate tradeDate);
+    void updateReportUrl(String stockCode, LocalDate tradeDate, String reportUrl);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -5,16 +5,20 @@ import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.repository.VolatilityRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.time.LocalDate.now;
-
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -22,32 +26,62 @@ public class VolatilityCommandServiceImpl implements VolatilityCommandService {
 
     private final VolatilityRepository volatilityRepository;
 
+    /**
+     * 같은 거래일에 다시 실행해도 결과가 같도록 해당 거래일의 집합을 교체한다.
+     * 단 전량 삭제 후 재삽입하면 콜백으로 채워진 reportUrl이 유실되므로,
+     * 이미 있는 종목은 갱신하고 새 종목만 추가한다.
+     */
     @Override
-    public void saveTopVolatilityStocks(List<VolatilitySignal> topSignals) {
-        LocalDate today = now();
-        LocalDateTime start = today.atStartOfDay();
-        LocalDateTime end = today.plusDays(1).atStartOfDay();
-        volatilityRepository.deleteAllByCreatedDateBetween(start, end);
+    public void saveTopVolatilityStocks(List<VolatilitySignal> topSignals, LocalDate tradeDate) {
+        // 탐지 결과가 비었는데 기존 기록을 지우면 그날 이력이 통째로 사라진다.
+        if (topSignals.isEmpty()) {
+            log.warn("저장할 변동성 종목이 없습니다. 기존 기록을 유지합니다. tradeDate={}", tradeDate);
+            return;
+        }
 
-        List<Volatility> volatilities = topSignals.stream()
-                .map(signal -> Volatility.builder()
-                        .stockCode(signal.stockCode())
-                        .stockName(signal.stockName())
-                        .reportUrl(null)
-                        .build())
-                .collect(Collectors.toList());
+        Map<String, Volatility> existingByCode = volatilityRepository.findAllByTradeDateOrderByIdAsc(tradeDate)
+                .stream()
+                .collect(Collectors.toMap(Volatility::getStockCode, Function.identity()));
 
-        volatilityRepository.saveAll(volatilities);
+        Set<String> selectedCodes = new LinkedHashSet<>();
+        List<Volatility> toInsert = new ArrayList<>();
+
+        for (VolatilitySignal signal : topSignals) {
+            selectedCodes.add(signal.stockCode());
+
+            Volatility existing = existingByCode.get(signal.stockCode());
+            if (existing != null) {
+                // reportUrl은 건드리지 않는다. 변경 감지로 종목명만 갱신된다.
+                existing.updateStockName(signal.stockName());
+                continue;
+            }
+
+            toInsert.add(Volatility.builder()
+                    .stockCode(signal.stockCode())
+                    .stockName(signal.stockName())
+                    .tradeDate(tradeDate)
+                    .reportUrl(null)
+                    .build());
+        }
+
+        // 재실행으로 상위 목록에서 빠진 종목. 그날의 상위 종목이 아니므로 남겨둘 이유가 없다.
+        List<Volatility> dropped = existingByCode.values().stream()
+                .filter(v -> !selectedCodes.contains(v.getStockCode()))
+                .toList();
+
+        if (!dropped.isEmpty()) {
+            volatilityRepository.deleteAll(dropped);
+        }
+        volatilityRepository.saveAll(toInsert);
+
+        log.info("변동성 상위 종목 저장 완료. tradeDate={} 선정={} 신규={} 갱신={} 제외={}",
+                tradeDate, topSignals.size(), toInsert.size(),
+                topSignals.size() - toInsert.size(), dropped.size());
     }
 
     @Override
-    public void updateReportUrl(String stockCode, LocalDate reportDate, String reportUrl) {
-        LocalDateTime start = reportDate.atStartOfDay();
-        LocalDateTime end = reportDate.plusDays(1).atStartOfDay();
-
-        Volatility volatility = volatilityRepository
-                .findFirstByStockCodeAndCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(
-                        stockCode, start, end)
+    public void updateReportUrl(String stockCode, LocalDate tradeDate, String reportUrl) {
+        Volatility volatility = volatilityRepository.findByStockCodeAndTradeDate(stockCode, tradeDate)
                 .orElseThrow(VolatilityHandler::volatilityNotFound);
 
         volatility.updateReportUrl(reportUrl);

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImpl.java
@@ -39,7 +39,8 @@ public class VolatilityCommandServiceImpl implements VolatilityCommandService {
             return;
         }
 
-        Map<String, Volatility> existingByCode = volatilityRepository.findAllByTradeDateOrderByIdAsc(tradeDate)
+        // 잠금 조회다. 같은 거래일에 두 탐지가 동시에 들어오면 뒤엣것이 앞엣것의 커밋을 기다린다.
+        Map<String, Volatility> existingByCode = volatilityRepository.findAllByTradeDateForUpdate(tradeDate)
                 .stream()
                 .collect(Collectors.toMap(Volatility::getStockCode, Function.identity()));
 

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionService.java
@@ -1,10 +1,11 @@
 package com.example.demo.domain.volatility.service;
 
+import com.example.demo.domain.volatility.entity.VolatilityDetectionResult;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
 
 import java.util.List;
 
 public interface VolatilityDetectionService {
-    List<VolatilitySignal> detect(int topN);
+    VolatilityDetectionResult detect(int topN);
     List<VolatilitySignal> selectTop(List<VolatilitySignal> signals, int universeSize, int topN);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
@@ -13,13 +13,12 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.example.demo.common.consts.StaticVariable.SEOUL_ZONE;
 
 @Slf4j
 @Service
@@ -41,6 +40,10 @@ public class VolatilityDetectionServiceImpl implements VolatilityDetectionServic
      * "전 종목 실패"만 막는 가드로는 이 경우를 잡지 못한다.
      */
     private static final double MIN_ANALYZED_RATIO = 0.8;
+
+    /** STRICT 해석이라 존재하지 않는 날짜를 보정 없이 거부한다. STRICT에서는 yyyy가 아니라 uuuu다. */
+    private static final DateTimeFormatter TRADE_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuuMMdd").withResolverStyle(ResolverStyle.STRICT);
 
     private final KrxService krxService;
 
@@ -86,24 +89,12 @@ public class VolatilityDetectionServiceImpl implements VolatilityDetectionServic
     }
 
     /**
-     * 거래일은 KRX 응답을 기준으로 삼는다. 서버 시각을 쓰면 타임존이나 자정 경계에서
-     * 저장된 날짜와 실제 거래일이 어긋난다.
-     * 응답에 값이 없을 때만 서버 날짜로 대체하되, 조용히 넘어가지 않도록 경고를 남긴다.
+     * 거래일은 KRX 응답을 기준으로 삼는다. 서버 날짜로 대체하면 휴장일이나 응답 오류일 때
+     * 실제 거래일과 다른 Volatility와 리포트가 만들어지므로, 대체하지 않고 실패시킨다.
+     * 값의 존재와 형식은 KrxService가 경계에서 이미 검증했다.
      */
     private LocalDate resolveTradeDate(String effectiveTradeDate) {
-        if (effectiveTradeDate != null && !effectiveTradeDate.isBlank()) {
-            try {
-                return LocalDate.parse(effectiveTradeDate, DateTimeFormatter.BASIC_ISO_DATE);
-            } catch (DateTimeParseException e) {
-                log.warn("effective_trade_date 파싱 실패. value={}", effectiveTradeDate);
-            }
-        } else {
-            log.warn("KRX 응답에 effective_trade_date가 없습니다.");
-        }
-
-        LocalDate fallback = LocalDate.now(SEOUL_ZONE);
-        log.warn("거래일을 서버 날짜로 대체합니다. tradeDate={}", fallback);
-        return fallback;
+        return LocalDate.parse(effectiveTradeDate, TRADE_DATE_FORMATTER);
     }
 
     /**

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImpl.java
@@ -2,29 +2,50 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
 import com.example.demo.api.krx.service.KrxService;
+import com.example.demo.domain.volatility.entity.VolatilityDetectionResult;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.util.VolatilityAlertEvaluator;
 import com.example.demo.domain.volatility.util.VolatilityIndicatorCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.example.demo.common.consts.StaticVariable.SEOUL_ZONE;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class VolatilityDetectionServiceImpl implements VolatilityDetectionService {
-    private static final double COMBINED_SCORE_WEIGHT = 0.7;
-    private static final double MARKET_CAP_WEIGHT = 0.3;
+    /**
+     * 시총 가중치는 소형주 독식을 막는 보정이지 순위 기준이 아니다.
+     * 상위권 경쟁은 대체로 점수가 높은 종목들 사이에서 벌어지는데, 그 구간의 변동성 점수 폭은
+     * 0.3 안팎인 반면 시총 가중치는 항상 0~1 전 구간을 쓴다. 0.3을 주면 정작 경쟁 구간에서
+     * 시총이 변동성보다 큰 영향을 갖게 되므로, 보정 역할에 맞게 0.15로 낮춘다.
+     */
+    private static final double COMBINED_SCORE_WEIGHT = 0.85;
+    private static final double MARKET_CAP_WEIGHT = 0.15;
+
+    /**
+     * 수신 종목 중 이 비율만큼은 분석에 성공해야 그 회차를 신뢰한다.
+     * 종목별 실패는 스킵으로 넘기지만, 너무 많이 빠지면 상위 10종목 자체가 표본 부족으로 왜곡된다.
+     * 그대로 저장하면 그날 기존 기록이 적은 수의 결과로 교체되면서 reportUrl까지 함께 사라진다.
+     * "전 종목 실패"만 막는 가드로는 이 경우를 잡지 못한다.
+     */
+    private static final double MIN_ANALYZED_RATIO = 0.8;
 
     private final KrxService krxService;
 
     @Override
-    public List<VolatilitySignal> detect(int topN) {
+    public VolatilityDetectionResult detect(int topN) {
         KrxOhlcvResponseDto response = krxService.getTopMarketCapOhlcv(topN);
 
         List<VolatilitySignal> signals = new ArrayList<>();
@@ -42,7 +63,16 @@ public class VolatilityDetectionServiceImpl implements VolatilityDetectionServic
             log.warn("변동성 분석 스킵 {}건 / 수신 {}건 (요청 {}건)", skipped, received, topN);
         }
 
-        return signals;
+        if (signals.size() < received * MIN_ANALYZED_RATIO) {
+            log.error("분석에 성공한 종목이 너무 적어 탐지를 중단합니다. 수신={} 분석={} 최소={}",
+                    received, signals.size(), (int) Math.ceil(received * MIN_ANALYZED_RATIO));
+            throw VolatilityHandler.volatilityDetectionFailed();
+        }
+
+        return new VolatilityDetectionResult(
+                resolveTradeDate(response.getEffectiveTradeDate()),
+                resolveUniverseSize(response.getUniverseSize(), received),
+                signals);
     }
 
     @Override
@@ -55,9 +85,49 @@ public class VolatilityDetectionServiceImpl implements VolatilityDetectionServic
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 거래일은 KRX 응답을 기준으로 삼는다. 서버 시각을 쓰면 타임존이나 자정 경계에서
+     * 저장된 날짜와 실제 거래일이 어긋난다.
+     * 응답에 값이 없을 때만 서버 날짜로 대체하되, 조용히 넘어가지 않도록 경고를 남긴다.
+     */
+    private LocalDate resolveTradeDate(String effectiveTradeDate) {
+        if (effectiveTradeDate != null && !effectiveTradeDate.isBlank()) {
+            try {
+                return LocalDate.parse(effectiveTradeDate, DateTimeFormatter.BASIC_ISO_DATE);
+            } catch (DateTimeParseException e) {
+                log.warn("effective_trade_date 파싱 실패. value={}", effectiveTradeDate);
+            }
+        } else {
+            log.warn("KRX 응답에 effective_trade_date가 없습니다.");
+        }
+
+        LocalDate fallback = LocalDate.now(SEOUL_ZONE);
+        log.warn("거래일을 서버 날짜로 대체합니다. tradeDate={}", fallback);
+        return fallback;
+    }
+
+    /**
+     * 시총 가중치의 분모. 요청한 수(topN)를 그대로 쓰면 Lambda가 그보다 적게 보냈을 때
+     * 순위가 왜곡되므로, Lambda가 알려준 유니버스 크기를 쓰고 없으면 실제 수신 건수로 대체한다.
+     */
+    private int resolveUniverseSize(int universeSize, int receivedCount) {
+        if (universeSize > 0) {
+            return universeSize;
+        }
+        log.warn("KRX 응답의 universe_size가 유효하지 않습니다. 수신 건수로 대체합니다. received={}", receivedCount);
+        return receivedCount;
+    }
+
     private double combinedScore(VolatilitySignal signal, int universeSize) {
+        // 0으로 나누면 NaN이 되고, NaN은 정렬에서 최대값으로 취급되어 엉뚱한 종목이 상위로 올라온다.
+        if (universeSize <= 0) {
+            return COMBINED_SCORE_WEIGHT * signal.score();
+        }
+        // 응답이 요청보다 적게 와서 universeSize를 수신 건수로 대체한 경우, 시총 순위가
+        // universeSize를 넘을 수 있다. 그대로 두면 가중치가 음수가 되어 점수를 깎는다.
         double marketCapWeight = (universeSize - signal.marketCapRank() + 1) / (double) universeSize;
-        return COMBINED_SCORE_WEIGHT * signal.score() + MARKET_CAP_WEIGHT * marketCapWeight;
+        double clamped = Math.max(0.0, Math.min(1.0, marketCapWeight));
+        return COMBINED_SCORE_WEIGHT * signal.score() + MARKET_CAP_WEIGHT * clamped;
     }
 
     private VolatilitySignal analyze(KrxOhlcvResponseDto.StockOhlcv stock) {

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
@@ -9,4 +9,7 @@ public interface VolatilityQueryService {
     List<Volatility> getByTradeDate(LocalDate tradeDate);
     List<Volatility> getAllVolatilityByCode(String stockCode);
     List<Volatility> getLatestVolatility();
+
+    /** 해당 종목의 가장 최근 탐지 기록. 리포트를 연결할 행을 특정할 때 쓴다. */
+    Volatility getLatestByStockCode(String stockCode);
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryService.java
@@ -2,11 +2,11 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.domain.volatility.entity.Volatility;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface VolatilityQueryService {
-    List<Volatility> getAllVolatilityByDate(LocalDateTime start, LocalDateTime end);
+    List<Volatility> getByTradeDate(LocalDate tradeDate);
     List<Volatility> getAllVolatilityByCode(String stockCode);
-    List<Volatility> getTodayVolatility();
+    List<Volatility> getLatestVolatility();
 }

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.volatility.service;
 
 import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.exception.VolatilityHandler;
 import com.example.demo.domain.volatility.repository.VolatilityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,12 @@ public class VolatilityQueryServiceImpl implements VolatilityQueryService {
     @Override
     public List<Volatility> getAllVolatilityByCode(String stockCode) {
         return volatilityRepository.findAllByStockCodeOrderByTradeDateDesc(stockCode);
+    }
+
+    @Override
+    public Volatility getLatestByStockCode(String stockCode) {
+        return volatilityRepository.findFirstByStockCodeOrderByTradeDateDesc(stockCode)
+                .orElseThrow(VolatilityHandler::volatilityNotFound);
     }
 
     /**

--- a/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/volatility/service/VolatilityQueryServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -17,22 +16,24 @@ public class VolatilityQueryServiceImpl implements VolatilityQueryService {
     private final VolatilityRepository volatilityRepository;
 
     @Override
-    public List<Volatility> getAllVolatilityByDate(LocalDateTime start, LocalDateTime end) {
-        return volatilityRepository
-                .findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(start, end);
+    public List<Volatility> getByTradeDate(LocalDate tradeDate) {
+        return volatilityRepository.findAllByTradeDateOrderByIdAsc(tradeDate);
     }
 
     @Override
     public List<Volatility> getAllVolatilityByCode(String stockCode) {
-        return volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc(stockCode);
+        return volatilityRepository.findAllByStockCodeOrderByTradeDateDesc(stockCode);
     }
 
+    /**
+     * 탐지 기록이 있는 가장 최근 거래일의 종목들.
+     * "오늘"을 서버 시각으로 판단하면 휴장일이거나 KRX가 전 거래일을 내려준 경우 빈 목록이 되므로,
+     * 실제로 저장된 최근 거래일을 기준으로 삼는다.
+     */
     @Override
-    public List<Volatility> getTodayVolatility() {
-        LocalDate today = LocalDate.now();
-        LocalDateTime start = today.atStartOfDay();
-        LocalDateTime end = today.plusDays(1).atStartOfDay();
-        return volatilityRepository
-                .findAllByCreatedDateGreaterThanEqualAndCreatedDateLessThanOrderByCreatedDateDesc(start, end);
+    public List<Volatility> getLatestVolatility() {
+        return volatilityRepository.findFirstByOrderByTradeDateDesc()
+                .map(latest -> volatilityRepository.findAllByTradeDateOrderByIdAsc(latest.getTradeDate()))
+                .orElseGet(List::of);
     }
 }

--- a/src/main/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluator.java
+++ b/src/main/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluator.java
@@ -34,23 +34,27 @@ public class VolatilityAlertEvaluator {
     public record AlertResult(double score, boolean alert, List<String> reasons) {
     }
 
+    /**
+     * 각 조건은 지표가 유한한 값일 때만 판정한다.
+     * isNaN만 검사하면 0 나누기로 생긴 Infinity가 그대로 통과해 임계값을 무조건 만족시킨다.
+     */
     public static AlertResult evaluate(IndicatorSnapshot snapshot) {
         List<String> reasons = new ArrayList<>();
         double score = 0.0;
 
-        if (!Double.isNaN(snapshot.dailyReturnPct())
+        if (Double.isFinite(snapshot.dailyReturnPct())
                 && Math.abs(snapshot.dailyReturnPct()) >= DAILY_RETURN_ABS_THRESHOLD) {
             reasons.add(REASON_DAILY_RETURN);
             score += WEIGHT_DAILY_RETURN;
         }
 
-        if (!Double.isNaN(snapshot.intradayRangePct())
+        if (Double.isFinite(snapshot.intradayRangePct())
                 && snapshot.intradayRangePct() >= INTRADAY_RANGE_THRESHOLD) {
             reasons.add(REASON_INTRADAY_RANGE);
             score += WEIGHT_INTRADAY_RANGE;
         }
 
-        if (!Double.isNaN(snapshot.volumeSpikeRatio())
+        if (Double.isFinite(snapshot.volumeSpikeRatio())
                 && snapshot.volumeSpikeRatio() >= VOLUME_SPIKE_THRESHOLD) {
             reasons.add(REASON_VOLUME_SPIKE);
             score += WEIGHT_VOLUME_SPIKE;
@@ -58,7 +62,7 @@ public class VolatilityAlertEvaluator {
 
         // bb_percent_b 상단/하단은 같은 지표의 양끝단이라 가중치는 한 번만 반영.
         boolean bbExtreme = false;
-        if (!Double.isNaN(snapshot.bbPercentB())) {
+        if (Double.isFinite(snapshot.bbPercentB())) {
             if (snapshot.bbPercentB() >= BB_PERCENT_B_HIGH) {
                 reasons.add(REASON_BB_HIGH);
                 bbExtreme = true;
@@ -72,7 +76,7 @@ public class VolatilityAlertEvaluator {
             score += WEIGHT_BB_EXTREME;
         }
 
-        if (!Double.isNaN(snapshot.vol20Quantile())
+        if (Double.isFinite(snapshot.vol20Quantile())
                 && snapshot.vol20Quantile() >= VOL20_QUANTILE_THRESHOLD) {
             reasons.add(REASON_VOL20_QUANTILE);
             score += WEIGHT_VOL20_QUANTILE;

--- a/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
+++ b/src/main/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculator.java
@@ -51,11 +51,13 @@ public class VolatilityIndicatorCalculator {
 
     static double dailyReturnPct(double[] close) {
         int n = close.length;
-        return (close[n - 1] / close[n - 2] - 1.0) * 100.0;
+        double previousClose = close[n - 2];
+        // 0으로 나누면 Infinity가 나오는데, Infinity는 NaN 가드를 통과해 임계값 판정을 그대로 넘어간다.
+        return previousClose == 0.0 ? Double.NaN : (close[n - 1] / previousClose - 1.0) * 100.0;
     }
 
     static double intradayRangePct(double high, double low, double close) {
-        return (high - low) / close * 100.0;
+        return close == 0.0 ? Double.NaN : (high - low) / close * 100.0;
     }
 
     static double bbPercentB(double[] close) {
@@ -127,14 +129,14 @@ public class VolatilityIndicatorCalculator {
     }
 
     static double percentileRank(double[] series, double latest) {
-        if (Double.isNaN(latest)) {
+        if (!Double.isFinite(latest)) {
             return Double.NaN;
         }
         int less = 0;
         int equal = 0;
         int validCount = 0;
         for (double v : series) {
-            if (Double.isNaN(v)) {
+            if (!Double.isFinite(v)) {
                 continue;
             }
             validCount++;

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.demo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DemoApplicationTests {
 
     @Test

--- a/src/test/java/com/example/demo/api/krx/dto/KrxKospi200ResponseDtoTest.java
+++ b/src/test/java/com/example/demo/api/krx/dto/KrxKospi200ResponseDtoTest.java
@@ -81,43 +81,30 @@ class KrxKospi200ResponseDtoTest {
     }
 
     /**
-     * StockUseCase가 errors를 두 갈래로 나누는 규칙.
-     * stocks에 있으면 시세만 실패한 것(편출 아님), 없으면 목록에 못 넣은 것(판정 보류).
+     * 종목 분류(신규/기존/편출 보류)는 DB와 비교해야 알 수 있으므로 syncStocks가 판정한다.
+     * 이 DTO가 보장해야 하는 건 두 가지뿐이다 - 가격 유무가 hasPrice로 갈리는 것, errors가 온전히 파싱되는 것.
      */
     @Test
-    void errors가_시세미수신과_미해결로_구분된다() throws Exception {
+    void 시세_갱신_대상은_hasPrice로_갈린다() throws Exception {
         KrxKospi200ResponseDto response = objectMapper.readValue(LAMBDA_RESPONSE, KrxKospi200ResponseDto.class);
 
-        Map<String, String> codeToName = response.getStocks().stream()
-                .collect(Collectors.toMap(
-                        KrxKospi200ResponseDto.StockPrice::getStockCode,
-                        KrxKospi200ResponseDto.StockPrice::getStockName));
-
-        Set<String> unresolvedStockCodes = response.getErrors().stream()
-                .map(KrxKospi200ResponseDto.ErrorItem::getStockCode)
-                .filter(code -> !codeToName.containsKey(code))
-                .collect(Collectors.toSet());
-
-        Set<String> priceUnavailableStockCodes = response.getErrors().stream()
-                .map(KrxKospi200ResponseDto.ErrorItem::getStockCode)
-                .filter(codeToName::containsKey)
-                .collect(Collectors.toSet());
-
-        // 거래정지·시세없음 종목은 구성종목으로 동기화된다(편출 아님)
-        assertThat(codeToName).containsKeys("005930", "000660", "035420");
-        assertThat(priceUnavailableStockCodes).containsExactlyInAnyOrder("000660", "035420");
-
-        // 종목명조차 못 받은 종목만 판정 보류
-        assertThat(unresolvedStockCodes).containsExactly("123456");
-
-        // 두 분류는 겹치지 않고, 합치면 errors 전체가 된다
-        assertThat(unresolvedStockCodes).doesNotContainAnyElementsOf(priceUnavailableStockCodes);
-        assertThat(unresolvedStockCodes.size() + priceUnavailableStockCodes.size())
-                .isEqualTo(response.getErrors().size());
-
-        // 시세 갱신은 가격이 있는 종목만
         assertThat(response.getStocks().stream().filter(KrxKospi200ResponseDto.StockPrice::hasPrice))
                 .extracting(KrxKospi200ResponseDto.StockPrice::getStockCode)
                 .containsExactly("005930");
+
+        assertThat(response.getStocks().stream().filter(s -> !s.hasPrice()))
+                .extracting(KrxKospi200ResponseDto.StockPrice::getStockCode)
+                .containsExactlyInAnyOrder("000660", "035420");
+    }
+
+    @Test
+    void errors는_가공_없이_그대로_파싱된다() throws Exception {
+        KrxKospi200ResponseDto response = objectMapper.readValue(LAMBDA_RESPONSE, KrxKospi200ResponseDto.class);
+
+        assertThat(response.getErrors())
+                .extracting(KrxKospi200ResponseDto.ErrorItem::getStockCode)
+                .containsExactlyInAnyOrder("000660", "035420", "123456");
+        assertThat(response.getErrors())
+                .allSatisfy(e -> assertThat(e.getReason()).isNotBlank());
     }
 }

--- a/src/test/java/com/example/demo/api/stock/mapper/StockConverterTest.java
+++ b/src/test/java/com/example/demo/api/stock/mapper/StockConverterTest.java
@@ -1,0 +1,90 @@
+package com.example.demo.api.stock.mapper;
+
+import com.example.demo.api.krx.dto.KrxKospi200ResponseDto;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
+import com.example.demo.domain.stock.entity.StockPriceSnapshot;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * KRX 응답을 동기화 입력으로 옮기는 경계 변환 검증.
+ * 시세 유무를 errors가 아니라 hasPrice로 가르는 것이 이 변환의 핵심이다.
+ */
+class StockConverterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String LAMBDA_RESPONSE = """
+            {
+              "tradeDate": "20260810",
+              "requestedCount": 4,
+              "stocks": [
+                { "stockCode": "005930", "stockName": "삼성전자",
+                  "openPrice": 71000, "closePrice": 72500 },
+                { "stockCode": "000660", "stockName": "SK하이닉스",
+                  "openPrice": null, "closePrice": null },
+                { "stockCode": "035420", "stockName": "NAVER",
+                  "openPrice": null, "closePrice": null }
+              ],
+              "errors": [
+                { "stockCode": "000660", "reason": "거래정지 또는 시세 0" },
+                { "stockCode": "035420", "reason": "시세 데이터 없음" },
+                { "stockCode": "123456", "reason": "종목명 조회 실패" }
+              ]
+            }
+            """;
+
+    private Kospi200SyncCommand convert() throws Exception {
+        return StockConverter.toKospi200SyncCommand(
+                objectMapper.readValue(LAMBDA_RESPONSE, KrxKospi200ResponseDto.class));
+    }
+
+    @Test
+    void 거래일은_응답의_tradeDate를_따른다() throws Exception {
+        assertThat(convert().tradeDate()).isEqualTo(LocalDate.of(2026, 8, 10));
+    }
+
+    @Test
+    void 구성종목은_errors와_무관하게_stocks_전체다() throws Exception {
+        // errors에 있어도 stocks에 있으면 코스피200 구성종목이다. 이탈로 오판하면 안 된다.
+        assertThat(convert().incomingStocks())
+                .containsOnlyKeys("005930", "000660", "035420")
+                .containsEntry("000660", "SK하이닉스");
+    }
+
+    @Test
+    void errors는_가공_없이_코드_집합으로만_넘어간다() throws Exception {
+        assertThat(convert().errorCodes())
+                .containsExactlyInAnyOrder("000660", "035420", "123456");
+    }
+
+    @Test
+    void 시세는_hasPrice_기준으로_갈린다() throws Exception {
+        Kospi200SyncCommand command = convert();
+
+        assertThat(command.priceSnapshots())
+                .extracting(StockPriceSnapshot::stockCode)
+                .containsExactly("005930");
+        assertThat(command.priceUnavailableStockCodes())
+                .containsExactly("000660", "035420");
+
+        // 두 목록을 합치면 구성종목 전체가 된다. 어느 쪽에도 안 잡혀 사라지는 종목이 없어야 한다.
+        assertThat(command.priceSnapshots().size() + command.priceUnavailableStockCodes().size())
+                .isEqualTo(command.incomingStocks().size());
+    }
+
+    @Test
+    void errors가_없어도_변환된다() throws Exception {
+        KrxKospi200ResponseDto response = objectMapper.readValue("""
+                { "tradeDate": "20260810", "requestedCount": 1,
+                  "stocks": [ { "stockCode": "005930", "stockName": "삼성전자",
+                                "openPrice": 71000, "closePrice": 72500 } ] }
+                """, KrxKospi200ResponseDto.class);
+
+        assertThat(StockConverter.toKospi200SyncCommand(response).errorCodes()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
+++ b/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
@@ -18,6 +18,8 @@ import org.mockito.Mockito;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportCallback;
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.SingleReportRequest;
 import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -132,6 +134,42 @@ class VolatilityUseCaseTest {
         useCase.runReportGeneration(reportRequest("{\"gptModel\":\" gpt-5-mini \"}"));
 
         assertThat(capturedReportJob().getGptModel()).isEqualTo("gpt-5-mini");
+    }
+
+    /**
+     * 콜백은 reportDate를 그대로 되돌려 (stockCode, tradeDate)로 행을 찾는다.
+     * 서버 날짜를 보내면 휴장일이나 과거 탐지 결과 재생성에서 행을 못 찾아
+     * 리포트는 만들어졌는데 reportUrl이 비는 상태가 된다.
+     */
+    @Test
+    void 단일_리포트도_저장된_거래일을_사용한다() throws Exception {
+        LocalDate storedTradeDate = LocalDate.of(2026, 8, 11);
+        Mockito.when(queryService.getLatestByStockCode("005930"))
+                .thenReturn(Volatility.builder()
+                        .stockCode("005930").stockName("삼성전자").tradeDate(storedTradeDate).build());
+
+        useCase.runSingleReportGeneration(new ObjectMapper().readValue(
+                "{\"stockCode\":\"005930\",\"stockName\":\"삼성전자\"}", SingleReportRequest.class));
+
+        ReportLambdaRequestDto job = capturedReportJob();
+        assertThat(job.getReportDate()).isEqualTo("20260811");
+        assertThat(job.getJobId()).isEqualTo("VOLATILITY_20260811_005930");
+    }
+
+    /**
+     * yyyyMMdd의 기본 SMART 해석은 20260231을 2월 말로 보정한다.
+     * 그대로 두면 콜백이 존재하지 않는 날짜로 엉뚱한 행을 갱신할 수 있다.
+     */
+    @Test
+    void 콜백의_존재하지_않는_날짜는_거부한다() throws Exception {
+        assertThatThrownBy(() -> useCase.handleReportCallback(new ObjectMapper().readValue(
+                "{\"stockCode\":\"005930\",\"reportDate\":\"20260231\","
+                        + "\"reportUrl\":\"https://example.com/x_analysis.html\"}", ReportCallback.class)))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorReasonHttpStatus().getCode())
+                .isEqualTo(VolatilityErrorStatus.REPORT_CALLBACK_INVALID_REQUEST.getCode());
+
+        verify(commandService, never()).updateReportUrl(any(), any(), any());
     }
 
     private ReportLambdaRequestDto capturedReportJob() {

--- a/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
+++ b/src/test/java/com/example/demo/api/volatility/service/VolatilityUseCaseTest.java
@@ -1,17 +1,24 @@
 package com.example.demo.api.volatility.service;
 
 import com.example.demo.api.report.client.ReportLambdaClient;
+import com.example.demo.api.report.dto.ReportLambdaRequestDto;
 import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.volatility.entity.Volatility;
+import com.example.demo.domain.volatility.entity.VolatilityDetectionResult;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.example.demo.domain.volatility.exception.VolatilityErrorStatus;
 import com.example.demo.domain.volatility.service.VolatilityCommandService;
 import com.example.demo.domain.volatility.service.VolatilityDetectionService;
 import com.example.demo.domain.volatility.service.VolatilityQueryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import static com.example.demo.api.volatility.dto.VolatilityRequestDto.ReportGenerationRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,12 +27,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
- * runDetection의 저장 가드 검증.
+ * runDetection의 저장 가드와, 거래일·유니버스 크기가 KRX 응답에서 그대로 전달되는지 검증.
  * detect()는 종목별 실패를 스킵하므로 전 종목이 실패해도 빈 리스트를 정상 반환한다.
- * 그 상태로 저장까지 진행하면 saveTopVolatilityStocks가 오늘 기록을 지우기만 하고 끝나므로,
- * 저장 이전에 중단되는지를 확인한다.
+ * 그 상태로 저장까지 진행하면 안 되므로, 저장 이전에 중단되는지를 확인한다.
  */
 class VolatilityUseCaseTest {
+
+    private static final LocalDate TRADE_DATE = LocalDate.of(2026, 8, 14);
 
     private final VolatilityQueryService queryService = Mockito.mock(VolatilityQueryService.class);
     private final VolatilityDetectionService detectionService = Mockito.mock(VolatilityDetectionService.class);
@@ -37,32 +45,32 @@ class VolatilityUseCaseTest {
 
     @Test
     void 전_종목_분석에_실패하면_저장하지_않고_예외를_던진다() {
-        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of());
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(detection(List.of()));
 
         assertThatThrownBy(useCase::runDetection)
                 .isInstanceOf(GeneralException.class)
                 .extracting(e -> ((GeneralException) e).getErrorReasonHttpStatus().getCode())
                 .isEqualTo(VolatilityErrorStatus.VOLATILITY_DETECTION_FAILED.getCode());
 
-        // 오늘 기록을 지우는 저장 경로에 진입하면 안 된다.
-        verify(commandService, never()).saveTopVolatilityStocks(any());
+        // 저장 경로에 진입하면 안 된다.
+        verify(commandService, never()).saveTopVolatilityStocks(any(), any());
     }
 
     @Test
     void 분석은_됐지만_알림_종목이_없으면_빈_결과로_저장한다() {
-        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of(signal("005930")));
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(detection(List.of(signal("005930"))));
         Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of());
 
         var result = useCase.runDetection();
 
         assertThat(result.getDetectedCount()).isZero();
-        verify(commandService).saveTopVolatilityStocks(List.of());
+        verify(commandService).saveTopVolatilityStocks(List.of(), TRADE_DATE);
     }
 
     @Test
     void 알림_종목이_있으면_그대로_저장한다() {
         VolatilitySignal detected = signal("005930");
-        Mockito.when(detectionService.detect(anyInt())).thenReturn(List.of(detected));
+        Mockito.when(detectionService.detect(anyInt())).thenReturn(detection(List.of(detected)));
         Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of(detected));
 
         var result = useCase.runDetection();
@@ -70,7 +78,82 @@ class VolatilityUseCaseTest {
         assertThat(result.getDetectedCount()).isEqualTo(1);
         assertThat(result.getStocks()).singleElement()
                 .satisfies(s -> assertThat(s.getStockCode()).isEqualTo("005930"));
-        verify(commandService).saveTopVolatilityStocks(List.of(detected));
+        verify(commandService).saveTopVolatilityStocks(List.of(detected), TRADE_DATE);
+    }
+
+    @Test
+    void 저장되는_거래일은_KRX_응답의_거래일을_따른다() {
+        VolatilitySignal detected = signal("005930");
+        LocalDate krxTradeDate = LocalDate.of(2026, 8, 11);
+        Mockito.when(detectionService.detect(anyInt()))
+                .thenReturn(new VolatilityDetectionResult(krxTradeDate, 100, List.of(detected)));
+        Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of(detected));
+
+        var result = useCase.runDetection();
+
+        assertThat(result.getTradeDate()).isEqualTo(krxTradeDate);
+        verify(commandService).saveTopVolatilityStocks(List.of(detected), krxTradeDate);
+    }
+
+    /**
+     * 시총 가중치의 분모를 요청 수(100)로 하드코딩하면, Lambda가 그보다 적게 보냈을 때 순위가 왜곡된다.
+     * 응답의 universe_size가 그대로 selectTop에 전달돼야 한다.
+     */
+    @Test
+    void 시총_가중치_분모는_응답의_universeSize를_사용한다() {
+        VolatilitySignal detected = signal("005930");
+        Mockito.when(detectionService.detect(anyInt()))
+                .thenReturn(new VolatilityDetectionResult(TRADE_DATE, 87, List.of(detected)));
+        Mockito.when(detectionService.selectTop(any(), anyInt(), anyInt())).thenReturn(List.of(detected));
+
+        useCase.runDetection();
+
+        verify(detectionService).selectTop(List.of(detected), 87, 10);
+    }
+
+    /**
+     * Lambda의 validate_job은 gptModel 키가 있으면 비어 있지 않은 문자열이길 요구한다.
+     * 빈 문자열은 @JsonInclude(NON_NULL)에 걸리지 않아 그대로 전송되고 Lambda 실행 오류가 된다.
+     * Swagger UI에서 선택 입력값을 비우고 보내면 실제로 이 경로를 탄다.
+     */
+    @Test
+    void gptModel이_공백이면_페이로드에서_제외된다() throws Exception {
+        Mockito.when(queryService.getLatestVolatility()).thenReturn(List.of(volatility()));
+
+        useCase.runReportGeneration(reportRequest("{\"gptModel\":\"   \"}"));
+
+        assertThat(capturedReportJob().getGptModel()).isNull();
+    }
+
+    @Test
+    void gptModel이_있으면_공백을_제거해_전달한다() throws Exception {
+        Mockito.when(queryService.getLatestVolatility()).thenReturn(List.of(volatility()));
+
+        useCase.runReportGeneration(reportRequest("{\"gptModel\":\" gpt-5-mini \"}"));
+
+        assertThat(capturedReportJob().getGptModel()).isEqualTo("gpt-5-mini");
+    }
+
+    private ReportLambdaRequestDto capturedReportJob() {
+        ArgumentCaptor<ReportLambdaRequestDto> captor = ArgumentCaptor.forClass(ReportLambdaRequestDto.class);
+        verify(reportLambdaClient).invokeCreateReport(captor.capture());
+        return captor.getValue();
+    }
+
+    private ReportGenerationRequest reportRequest(String json) throws Exception {
+        return new ObjectMapper().readValue(json, ReportGenerationRequest.class);
+    }
+
+    private Volatility volatility() {
+        return Volatility.builder()
+                .stockCode("005930")
+                .stockName("삼성전자")
+                .tradeDate(TRADE_DATE)
+                .build();
+    }
+
+    private VolatilityDetectionResult detection(List<VolatilitySignal> signals) {
+        return new VolatilityDetectionResult(TRADE_DATE, 100, signals);
     }
 
     private VolatilitySignal signal(String stockCode) {

--- a/src/test/java/com/example/demo/domain/stock/service/StockCommandServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/stock/service/StockCommandServiceImplTest.java
@@ -1,10 +1,14 @@
 package com.example.demo.domain.stock.service;
 
-import com.example.demo.api.stock.dto.StockSyncResultDto;
 import com.example.demo.common.config.JpaAuditingConfig;
+import com.example.demo.domain.stock.entity.Kospi200SyncCommand;
+import com.example.demo.domain.stock.entity.StockSyncOutcome;
 import com.example.demo.domain.stock.entity.Stock;
+import com.example.demo.domain.stock.entity.StockSyncResult;
 import com.example.demo.domain.stock.entity.StockPriceSnapshot;
 import com.example.demo.domain.stock.repository.StockRepository;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.stock.exception.StockErrorStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -19,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * 코스피200 동기화의 H2 기반 테스트.
@@ -43,7 +48,7 @@ class StockCommandServiceImplTest {
 
     @Test
     void 신규_종목은_활성으로_저장된다() {
-        StockSyncResultDto result = stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
+        StockSyncResult result = stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
 
         assertThat(result.addedCount()).isEqualTo(1);
         assertThat(stockRepository.findByStockCode("005930"))
@@ -55,7 +60,7 @@ class StockCommandServiceImplTest {
     void 편출된_종목은_삭제되지_않고_비활성으로_남는다() {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
 
-        StockSyncResultDto result = stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
+        StockSyncResult result = stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
 
         assertThat(result.deactivatedCount()).isEqualTo(1);
         // 행 자체는 남아 있어야 한다
@@ -69,7 +74,7 @@ class StockCommandServiceImplTest {
     void 재편입되면_다시_활성으로_되돌린다() {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
         stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());                       // 편출
-        StockSyncResultDto result = stockCommandService.syncStocks(
+        StockSyncResult result = stockCommandService.syncStocks(
                 source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());             // 재편입
 
         assertThat(result.reactivatedCount()).isEqualTo(1);
@@ -85,7 +90,7 @@ class StockCommandServiceImplTest {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
 
         // 000660은 여전히 구성종목이지만 거래정지 등으로 시세를 못 받아 sourceStocks에서 빠진 상황
-        StockSyncResultDto result = stockCommandService.syncStocks(
+        StockSyncResult result = stockCommandService.syncStocks(
                 source("005930", "삼성전자"), Set.of("000660"));
 
         assertThat(result.deactivatedCount()).isZero();
@@ -99,7 +104,7 @@ class StockCommandServiceImplTest {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
 
         // 보류 목록에 다른 종목만 있는 경우 — 000660은 정상적으로 편출 판정
-        StockSyncResultDto result = stockCommandService.syncStocks(
+        StockSyncResult result = stockCommandService.syncStocks(
                 source("005930", "삼성전자"), Set.of("999999"));
 
         assertThat(result.deactivatedCount()).isEqualTo(1);
@@ -112,7 +117,7 @@ class StockCommandServiceImplTest {
     void 종목명이_바뀌면_갱신한다() {
         stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
 
-        StockSyncResultDto result = stockCommandService.syncStocks(source("005930", "삼성전자우"), Set.of());
+        StockSyncResult result = stockCommandService.syncStocks(source("005930", "삼성전자우"), Set.of());
 
         assertThat(result.updatedCount()).isEqualTo(1);
         assertThat(stockRepository.findByStockCode("005930"))
@@ -125,10 +130,12 @@ class StockCommandServiceImplTest {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
         stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());   // 000660 편출
 
-        assertThat(stockRepository.findAllByIsActive(true))
+        assertThat(stockRepository.findAll())
+                .filteredOn(stock -> Boolean.TRUE.equals(stock.getIsActive()))
                 .extracting(Stock::getStockCode)
                 .containsExactly("005930");
-        assertThat(stockRepository.findAllByIsActive(false))
+        assertThat(stockRepository.findAll())
+                .filteredOn(stock -> !Boolean.TRUE.equals(stock.getIsActive()))
                 .extracting(Stock::getStockCode)
                 .containsExactly("000660");
         assertThat(stockRepository.findAll())
@@ -136,17 +143,49 @@ class StockCommandServiceImplTest {
                 .containsExactlyInAnyOrder("005930", "000660");
     }
 
+    /**
+     * 응답에 없는 종목이 편출인지 일시적 실패인지는 DB와 비교해야만 갈린다.
+     * errors에 있으면 보류(활성 유지), 없으면 편출.
+     */
+    @Test
+    void 응답에_없는_종목은_errors_여부로_편출과_보류가_갈린다() {
+        stockCommandService.syncStocks(
+                source("005930", "삼성전자", "000660", "SK하이닉스", "035420", "NAVER"), Set.of());
+
+        // 이번 응답에는 005930만 왔고, 000660은 Lambda가 실패 보고, 035420은 아무 소식 없음
+        StockSyncResult result =
+                stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of("000660"));
+
+        assertThat(result.unresolvedStockCodes()).containsExactly("000660");
+        assertThat(result.deactivatedCount()).isEqualTo(1);
+
+        assertThat(stockRepository.findByStockCode("000660")).get()
+                .satisfies(s -> assertThat(s.getIsActive()).isTrue());
+        assertThat(stockRepository.findByStockCode("035420")).get()
+                .satisfies(s -> assertThat(s.getIsActive()).isFalse());
+    }
+
+    @Test
+    void 신규_종목은_errors와_무관하게_추가된다() {
+        StockSyncResult result = stockCommandService.syncStocks(
+                source("005930", "삼성전자"), Set.of("999999"));
+
+        assertThat(result.addedCount()).isEqualTo(1);
+        // DB에 없던 종목은 보류할 상태 자체가 없으므로 목록에 잡히지 않는다.
+        assertThat(result.unresolvedStockCodes()).isEmpty();
+    }
+
     @Test
     void 여러_종목의_시세를_한_번에_갱신한다() {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
         LocalDate tradeDate = LocalDate.of(2026, 8, 2);
 
-        int updated = stockCommandService.updateStockPrices(List.of(
+        var priceResult = stockCommandService.updateStockPrices(List.of(
                 new StockPriceSnapshot("005930", new BigDecimal("71000"), new BigDecimal("72500")),
                 new StockPriceSnapshot("000660", new BigDecimal("180000"), new BigDecimal("183000"))
         ), tradeDate);
 
-        assertThat(updated).isEqualTo(2);
+        assertThat(priceResult.updatedCount()).isEqualTo(2);
         assertThat(stockRepository.findByStockCode("005930")).get().satisfies(s -> {
             assertThat(s.getOpenPrice()).isEqualByComparingTo("71000");
             assertThat(s.getClosePrice()).isEqualByComparingTo("72500");
@@ -154,16 +193,88 @@ class StockCommandServiceImplTest {
         });
     }
 
+    /**
+     * syncStocksAndPrices는 목록 저장 뒤에 시세를 갱신한다.
+     * 신규 종목의 insert가 flush되지 않으면 시세 조회에서 안 잡혀 첫날 시세가 통째로 비게 되므로,
+     * 같은 실행 안에서 반영되는지를 고정한다.
+     */
+    /**
+     * 지수 구성종목 목록이 일부만 조회되면 빠진 종목이 전부 편출로 판정된다.
+     * "목록이 비었을 때"만 막는 가드로는 못 잡으므로, 규모로 한 번 더 막는다.
+     */
+    @Test
+    void 편출이_비정상적으로_많으면_동기화를_중단한다() {
+        stockCommandService.syncStocks(manyStocks(30), Set.of());
+
+        // 30종목 중 1종목만 수신 → 29종목이 편출 판정
+        assertThatThrownBy(() -> stockCommandService.syncStocks(source("000001", "종목1"), Set.of()))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorReasonHttpStatus().getCode())
+                .isEqualTo(StockErrorStatus.STOCK_ABNORMAL_DEACTIVATION.getCode());
+    }
+
+    @Test
+    void 정상_범위의_편출은_그대로_반영한다() {
+        stockCommandService.syncStocks(manyStocks(30), Set.of());
+
+        // 30종목 중 25종목 수신 → 5종목 편출. 정기변경 수준이라 통과해야 한다.
+        StockSyncResult result = stockCommandService.syncStocks(manyStocks(25), Set.of());
+
+        assertThat(result.deactivatedCount()).isEqualTo(5);
+    }
+
+    @Test
+    void 대량_이탈이어도_errors로_보류되면_중단하지_않는다() {
+        stockCommandService.syncStocks(manyStocks(30), Set.of());
+
+        // 29종목이 목록에서 빠졌지만 전부 Lambda가 실패 보고한 것이므로 편출이 아니다.
+        Set<String> allButFirst = manyStocks(30).keySet().stream()
+                .filter(code -> !code.equals("000001"))
+                .collect(java.util.stream.Collectors.toSet());
+        StockSyncResult result = stockCommandService.syncStocks(source("000001", "종목1"), allButFirst);
+
+        assertThat(result.deactivatedCount()).isZero();
+        assertThat(result.unresolvedStockCodes()).hasSize(29);
+    }
+
+    private Map<String, String> manyStocks(int count) {
+        Map<String, String> stocks = new java.util.LinkedHashMap<>();
+        for (int i = 1; i <= count; i++) {
+            stocks.put(String.format("%06d", i), "종목" + i);
+        }
+        return stocks;
+    }
+
+    @Test
+    void 신규_종목의_시세도_같은_실행에서_반영된다() {
+        LocalDate tradeDate = LocalDate.of(2026, 8, 2);
+
+        StockSyncOutcome outcome = stockCommandService.syncStocksAndPrices(new Kospi200SyncCommand(
+                tradeDate,
+                source("005930", "삼성전자"),
+                Set.of(),
+                List.of(new StockPriceSnapshot("005930", new BigDecimal("71000"), new BigDecimal("72500"))),
+                List.of()));
+
+        assertThat(outcome.syncResult().addedCount()).isEqualTo(1);
+        assertThat(outcome.priceUpdatedCount()).isEqualTo(1);
+        assertThat(outcome.priceUpdateSkippedStockCodes()).isEmpty();
+        assertThat(stockRepository.findByStockCode("005930")).get()
+                .satisfies(s -> assertThat(s.getClosePrice()).isEqualByComparingTo("72500"));
+    }
+
     @Test
     void DB에_없는_종목의_시세는_건너뛴다() {
         stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());
 
-        int updated = stockCommandService.updateStockPrices(List.of(
+        var priceResult = stockCommandService.updateStockPrices(List.of(
                 new StockPriceSnapshot("005930", new BigDecimal("71000"), new BigDecimal("72500")),
                 new StockPriceSnapshot("999999", new BigDecimal("1000"), new BigDecimal("1100"))
         ), LocalDate.of(2026, 8, 2));
 
-        assertThat(updated).isEqualTo(1);
+        assertThat(priceResult.updatedCount()).isEqualTo(1);
+        // 건수만으로는 어느 종목이 빠졌는지 알 수 없어 추적이 안 된다. 코드까지 돌려준다.
+        assertThat(priceResult.skippedStockCodes()).containsExactly("999999");
         assertThat(stockRepository.findAll()).hasSize(1);
     }
 
@@ -172,12 +283,13 @@ class StockCommandServiceImplTest {
         stockCommandService.syncStocks(source("005930", "삼성전자", "000660", "SK하이닉스"), Set.of());
         stockCommandService.syncStocks(source("005930", "삼성전자"), Set.of());   // 000660 편출
 
-        int updated = stockCommandService.updateStockPrices(List.of(
+        var priceResult = stockCommandService.updateStockPrices(List.of(
                 new StockPriceSnapshot("005930", new BigDecimal("71000"), new BigDecimal("72500")),
                 new StockPriceSnapshot("000660", new BigDecimal("180000"), new BigDecimal("183000"))
         ), LocalDate.of(2026, 8, 2));
 
-        assertThat(updated).isEqualTo(1);
+        assertThat(priceResult.updatedCount()).isEqualTo(1);
+        assertThat(priceResult.skippedStockCodes()).containsExactly("000660");
         assertThat(stockRepository.findByStockCode("000660")).get().satisfies(s -> {
             assertThat(s.getOpenPrice()).isNull();
             assertThat(s.getClosePrice()).isNull();

--- a/src/test/java/com/example/demo/domain/stock/service/StockQueryServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/stock/service/StockQueryServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.example.demo.domain.stock.service;
+
+import com.example.demo.common.config.JpaAuditingConfig;
+import com.example.demo.domain.stock.entity.Stock;
+import com.example.demo.domain.stock.repository.StockRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 종목 조회의 isActive 필터 검증.
+ * isActive는 선택 파라미터라 null이 정상 입력이며, 이때 전체가 조회돼야 한다.
+ */
+@DataJpaTest
+@Import({StockQueryServiceImpl.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:stockquery;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class StockQueryServiceImplTest {
+
+    private static final Pageable PAGE = PageRequest.of(0, 20);
+
+    @Autowired
+    private StockQueryService stockQueryService;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @BeforeEach
+    void setUp() {
+        stockRepository.deleteAll();
+        stockRepository.save(Stock.builder().stockCode("005930").stockName("삼성전자").build());
+
+        Stock delisted = Stock.builder().stockCode("000660").stockName("SK하이닉스").build();
+        delisted.deactivate();
+        stockRepository.save(delisted);
+    }
+
+    @Test
+    void isActive가_null이면_예외없이_전체를_조회한다() {
+        assertThatCode(() -> stockQueryService.getAllStocks(null, PAGE))
+                .doesNotThrowAnyException();
+
+        assertThat(stockQueryService.getAllStocks(null, PAGE))
+                .extracting(Stock::getStockCode)
+                .containsExactlyInAnyOrder("005930", "000660");
+    }
+
+    @Test
+    void isActive가_true면_편입_종목만_조회한다() {
+        assertThat(stockQueryService.getAllStocks(true, PAGE))
+                .extracting(Stock::getStockCode)
+                .containsExactly("005930");
+    }
+
+    @Test
+    void isActive가_false면_전체를_조회한다() {
+        assertThat(stockQueryService.getAllStocks(false, PAGE))
+                .extracting(Stock::getStockCode)
+                .containsExactlyInAnyOrder("005930", "000660");
+    }
+}

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityCommandServiceImplTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 class VolatilityCommandServiceImplTest {
 
+    private static final LocalDate TRADE_DATE = LocalDate.of(2026, 8, 14);
+
     @Autowired
     private VolatilityCommandService volatilityCommandService;
 
@@ -40,7 +43,7 @@ class VolatilityCommandServiceImplTest {
         volatilityCommandService.saveTopVolatilityStocks(List.of(
                 signal("005930", "삼성전자"),
                 signal("000660", "SK하이닉스")
-        ));
+        ), TRADE_DATE);
 
         List<Volatility> saved = volatilityRepository.findAll();
 
@@ -50,45 +53,81 @@ class VolatilityCommandServiceImplTest {
         assertThat(saved).extracting(Volatility::getStockName)
                 .containsExactlyInAnyOrder("삼성전자", "SK하이닉스");
         assertThat(saved).allSatisfy(v -> assertThat(v.getReportUrl()).isNull());
+        assertThat(saved).allSatisfy(v -> assertThat(v.getTradeDate()).isEqualTo(TRADE_DATE));
     }
 
     @Test
-    void createdDate가_자동으로_채워져_날짜별_조회가_가능하다() {
-        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
+    void createdDate가_자동으로_채워진다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
 
-        List<Volatility> saved = volatilityRepository.findAll();
-
-        assertThat(saved).singleElement()
+        assertThat(volatilityRepository.findAll()).singleElement()
                 .satisfies(v -> assertThat(v.getCreatedDate()).isNotNull());
     }
 
     @Test
-    void 같은_날_다시_실행하면_오늘_기록을_교체한다() {
-        // 탐지는 하루 한 번이 기준이므로 재실행은 누적이 아니라 교체다(stock_code 중복 방지).
-        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
-        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")));
+    void 같은_거래일에_다시_실행하면_누적되지_않고_교체된다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
 
-        assertThat(volatilityRepository.findAllByStockCodeOrderByCreatedDateDesc("005930")).hasSize(1);
+        assertThat(volatilityRepository.findAllByStockCodeOrderByTradeDateDesc("005930")).hasSize(1);
     }
 
     @Test
-    void 재실행_시_이전_선정_종목은_남지_않는다() {
+    void 재실행으로_상위_목록에서_빠진_종목은_남지_않는다() {
         volatilityCommandService.saveTopVolatilityStocks(List.of(
                 signal("005930", "삼성전자"),
                 signal("000660", "SK하이닉스")
-        ));
-        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("035420", "NAVER")));
+        ), TRADE_DATE);
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("035420", "NAVER")), TRADE_DATE);
 
-        assertThat(volatilityRepository.findAll())
+        assertThat(volatilityRepository.findAllByTradeDateOrderByIdAsc(TRADE_DATE))
                 .extracting(Volatility::getStockCode)
                 .containsExactly("035420");
     }
 
+    /**
+     * 이번 수정의 핵심 회귀 테스트.
+     * 이전 구현은 당일 기록을 전량 삭제 후 재삽입해서, 콜백으로 채워진 reportUrl이 통째로 사라졌다.
+     */
+    @Test
+    void 같은_거래일_재실행에도_이미_생성된_reportUrl은_보존된다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
+        volatilityCommandService.updateReportUrl("005930", TRADE_DATE, "https://example.com/report.html");
+
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
+
+        assertThat(volatilityRepository.findByStockCodeAndTradeDate("005930", TRADE_DATE))
+                .get()
+                .extracting(Volatility::getReportUrl)
+                .isEqualTo("https://example.com/report.html");
+    }
+
+    @Test
+    void 빈_목록이면_기존_기록을_지우지_않는다() {
+        volatilityCommandService.saveTopVolatilityStocks(List.of(signal("005930", "삼성전자")), TRADE_DATE);
+
+        volatilityCommandService.saveTopVolatilityStocks(List.of(), TRADE_DATE);
+
+        assertThat(volatilityRepository.findAllByTradeDateOrderByIdAsc(TRADE_DATE)).hasSize(1);
+    }
+
     @Test
     void 빈_목록이면_아무것도_저장하지_않는다() {
-        volatilityCommandService.saveTopVolatilityStocks(List.of());
+        volatilityCommandService.saveTopVolatilityStocks(List.of(), TRADE_DATE);
 
         assertThat(volatilityRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void 거래일이_다르면_같은_종목도_별개로_쌓인다() {
+        volatilityCommandService.saveTopVolatilityStocks(
+                List.of(signal("005930", "삼성전자")), LocalDate.of(2026, 8, 13));
+        volatilityCommandService.saveTopVolatilityStocks(
+                List.of(signal("005930", "삼성전자")), LocalDate.of(2026, 8, 14));
+
+        assertThat(volatilityRepository.findAllByStockCodeOrderByTradeDateDesc("005930"))
+                .extracting(Volatility::getTradeDate)
+                .containsExactly(LocalDate.of(2026, 8, 14), LocalDate.of(2026, 8, 13));
     }
 
     private VolatilitySignal signal(String stockCode, String stockName) {

--- a/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/service/VolatilityDetectionServiceImplTest.java
@@ -2,17 +2,22 @@ package com.example.demo.domain.volatility.service;
 
 import com.example.demo.api.krx.dto.KrxOhlcvResponseDto;
 import com.example.demo.api.krx.service.KrxService;
+import com.example.demo.domain.volatility.entity.VolatilityDetectionResult;
 import com.example.demo.domain.volatility.entity.VolatilitySignal;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.demo.common.exception.GeneralException;
+import com.example.demo.domain.volatility.exception.VolatilityErrorStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * top10 선정 로직(selectTop)과 KRX Lambda 응답을 지표 계산으로 넘기는 오케스트레이션(detect) 유닛테스트.
@@ -60,18 +65,39 @@ class VolatilityDetectionServiceImplTest {
     }
 
     @Test
-    void combinedScore는_변동성점수0_7_시총가중치0_3으로_정렬된다() {
-        // 시총 1위(rank=1, marketCapWeight=1.0)이지만 score가 아주 낮은 종목
-        VolatilitySignal highCapLowScore = signal("HIGHCAP", 1, 0.05, true);
-        // 시총 100위(rank=100, marketCapWeight=0.01)이지만 score가 매우 높은 종목
-        VolatilitySignal lowCapHighScore = signal("LOWCAP", 100, 0.9, true);
+    void combinedScore는_변동성점수0_85_시총가중치0_15로_정렬된다() {
+        // 시총 1위(rank=1, marketCapWeight=1.0)이지만 조건 1개만 걸린 종목(score 0.30)
+        VolatilitySignal highCapLowScore = signal("HIGHCAP", 1, 0.30, true);
+        // 시총 100위(rank=100, marketCapWeight=0.01)이지만 조건 3개가 걸린 종목(score 0.75)
+        VolatilitySignal lowCapHighScore = signal("LOWCAP", 100, 0.75, true);
 
-        // combinedScore(highCapLowScore) = 0.7*0.05 + 0.3*1.00 = 0.335
-        // combinedScore(lowCapHighScore)  = 0.7*0.90 + 0.3*0.01 = 0.633
+        // combinedScore(highCapLowScore) = 0.85*0.30 + 0.15*1.00 = 0.405
+        // combinedScore(lowCapHighScore) = 0.85*0.75 + 0.15*0.01 = 0.639
+        // 가중치가 0.7/0.3이던 시절에는 각각 0.510 / 0.528로 사실상 동점이라,
+        // 대형주가 조건 하나만 걸려도 조건 셋을 만족한 소형주와 맞먹었다.
         List<VolatilitySignal> top = service.selectTop(
                 List.of(highCapLowScore, lowCapHighScore), UNIVERSE_SIZE, 10);
 
         assertThat(top).containsExactly(lowCapHighScore, highCapLowScore);
+    }
+
+    /**
+     * universeSize를 응답의 universe_size 대신 수신 건수로 대체한 경우, 시총 순위가
+     * universeSize를 넘을 수 있다. 가중치가 음수가 되면 같은 변동성 점수인데도 점수가 깎인다.
+     */
+    @Test
+    void 시총순위가_universeSize보다_커도_가중치는_음수가_되지_않는다() {
+        // universeSize=90, rank=100 -> 가중치 (90-100+1)/90 = -0.1
+        VolatilitySignal outOfRange = signal("OUTRANGE", 100, 0.15, true);
+        // universeSize=90, rank=70  -> 가중치 (90-70+1)/90 = 0.2333
+        VolatilitySignal inRange = signal("INRANGE", 70, 0.10, true);
+
+        // clamp 있음: OUTRANGE = 0.85*0.15 + 0.15*0     = 0.1275  > INRANGE = 0.120
+        // clamp 없음: OUTRANGE = 0.85*0.15 + 0.15*(-0.1) = 0.1125  < INRANGE = 0.120
+        // 즉 음수 가중치를 막지 않으면 순위가 뒤집힌다.
+        List<VolatilitySignal> top = service.selectTop(List.of(outOfRange, inRange), 90, 10);
+
+        assertThat(top).containsExactly(outOfRange, inRange);
     }
 
     @Test
@@ -79,8 +105,13 @@ class VolatilityDetectionServiceImplTest {
         Mockito.when(krxService.getTopMarketCapOhlcv(ArgumentMatchers.anyInt()))
                 .thenReturn(ohlcvResponse(stockJson("005930", "삼성전자", 1, syntheticCloses(60))));
 
-        List<VolatilitySignal> detected = service.detect(1);
+        VolatilityDetectionResult result = service.detect(1);
 
+        // 거래일과 유니버스 크기는 응답(effective_trade_date, universe_size)에서 그대로 실려 온다.
+        assertThat(result.tradeDate()).isEqualTo(LocalDate.of(2026, 7, 31));
+        assertThat(result.universeSize()).isEqualTo(100);
+
+        List<VolatilitySignal> detected = result.signals();
         assertThat(detected).hasSize(1);
         VolatilitySignal signal = detected.get(0);
         assertThat(signal.stockCode()).isEqualTo("005930");
@@ -89,18 +120,41 @@ class VolatilityDetectionServiceImplTest {
         assertThat(signal.dailyReturnPct()).isNotNaN();
     }
 
+    /**
+     * 종목별 실패는 스킵으로 넘기지만, 너무 많이 빠지면 상위 10종목이 표본 부족으로 왜곡된다.
+     * 그대로 저장하면 그날 기존 기록이 적은 결과로 교체되면서 reportUrl까지 사라진다.
+     */
     @Test
-    void 한_종목_계산이_실패해도_나머지_종목은_정상_처리된다() throws Exception {
-        // 60개 미만 배열은 VolatilityIndicatorCalculator.calculate()가 IllegalArgumentException을 던짐
-        String broken = stockJson("000660", "SK하이닉스", 2, syntheticCloses(5));
-        String valid = stockJson("005930", "삼성전자", 1, syntheticCloses(60));
+    void 분석_성공_종목이_기준_미만이면_탐지를_중단한다() throws Exception {
+        // 5종목 수신, 그중 3종목이 데이터 부족 → 성공 2/5 = 40% < 80%
         Mockito.when(krxService.getTopMarketCapOhlcv(ArgumentMatchers.anyInt()))
-                .thenReturn(ohlcvResponse(broken, valid));
+                .thenReturn(ohlcvResponse(
+                        stockJson("005930", "삼성전자", 1, syntheticCloses(60)),
+                        stockJson("000660", "SK하이닉스", 2, syntheticCloses(60)),
+                        stockJson("035420", "NAVER", 3, syntheticCloses(5)),
+                        stockJson("051910", "LG화학", 4, syntheticCloses(5)),
+                        stockJson("006400", "삼성SDI", 5, syntheticCloses(5))));
 
-        List<VolatilitySignal> detected = service.detect(2);
+        assertThatThrownBy(() -> service.detect(5))
+                .isInstanceOf(GeneralException.class)
+                .extracting(e -> ((GeneralException) e).getErrorReasonHttpStatus().getCode())
+                .isEqualTo(VolatilityErrorStatus.VOLATILITY_DETECTION_FAILED.getCode());
+    }
 
-        assertThat(detected).hasSize(1);
-        assertThat(detected.get(0).stockCode()).isEqualTo("005930");
+    @Test
+    void 스킵이_기준_이내면_실패_종목만_빼고_진행한다() throws Exception {
+        // 5종목 중 1종목만 데이터 부족 → 성공 4/5 = 80% >= 80%
+        Mockito.when(krxService.getTopMarketCapOhlcv(ArgumentMatchers.anyInt()))
+                .thenReturn(ohlcvResponse(
+                        stockJson("005930", "삼성전자", 1, syntheticCloses(60)),
+                        stockJson("000660", "SK하이닉스", 2, syntheticCloses(60)),
+                        stockJson("035420", "NAVER", 3, syntheticCloses(60)),
+                        stockJson("051910", "LG화학", 4, syntheticCloses(60)),
+                        stockJson("006400", "삼성SDI", 5, syntheticCloses(5))));
+
+        assertThat(service.detect(5).signals())
+                .extracting(VolatilitySignal::stockCode)
+                .containsExactlyInAnyOrder("005930", "000660", "035420", "051910");
     }
 
     private VolatilitySignal signal(String stockCode, int rank, double score, boolean alert) {

--- a/src/test/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluatorTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/util/VolatilityAlertEvaluatorTest.java
@@ -82,4 +82,36 @@ class VolatilityAlertEvaluatorTest {
         assertThat(result.reasons()).containsExactly(VolatilityAlertEvaluator.REASON_BB_HIGH);
         assertThat(result.score()).isCloseTo(0.10, within(1e-9));
     }
+
+    /**
+     * 0으로 나누면 NaN이 아니라 Infinity가 나온다.
+     * isNaN만 검사하면 Infinity가 통과해 모든 임계값을 무조건 만족시키므로,
+     * 값이 없는 종목이 만점에 가까운 점수로 상위에 올라온다.
+     */
+    @Test
+    void Infinity_지표는_아무_조건도_충족하지_않음() {
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+                Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+                Double.POSITIVE_INFINITY
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).isEmpty();
+        assertThat(result.alert()).isFalse();
+        assertThat(result.score()).isZero();
+    }
+
+    @Test
+    void 음의_Infinity도_조건에서_제외된다() {
+        IndicatorSnapshot snapshot = new IndicatorSnapshot(
+                Double.NEGATIVE_INFINITY, 1.0, 10.0, 0.5, 10.0, 1.0, 0.1
+        );
+
+        AlertResult result = VolatilityAlertEvaluator.evaluate(snapshot);
+
+        assertThat(result.reasons()).isEmpty();
+        assertThat(result.score()).isZero();
+    }
 }

--- a/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
+++ b/src/test/java/com/example/demo/domain/volatility/util/VolatilityIndicatorCalculatorTest.java
@@ -31,6 +31,20 @@ class VolatilityIndicatorCalculatorTest {
                 .isCloseTo(expected, within(TOLERANCE));
     }
 
+    /**
+     * 다른 지표들과 마찬가지로 0 나누기는 Infinity가 아니라 NaN으로 돌려준다.
+     * Infinity는 평가 단계의 임계값 비교를 무조건 통과해버린다.
+     */
+    @Test
+    void 종가가_0이면_intradayRangePct는_NaN() {
+        assertThat(VolatilityIndicatorCalculator.intradayRangePct(110.0, 100.0, 0.0)).isNaN();
+    }
+
+    @Test
+    void 전일_종가가_0이면_dailyReturnPct는_NaN() {
+        assertThat(VolatilityIndicatorCalculator.dailyReturnPct(new double[]{100.0, 0.0, 105.0})).isNaN();
+    }
+
     @Test
     void bollingerPercentB_및_width_계산() {
         // 마지막 20개 종가 = 1..20 -> ma20=10.5, 표본표준편차=sqrt(35)
@@ -140,6 +154,29 @@ class VolatilityIndicatorCalculatorTest {
                 VolatilityIndicatorCalculator.calculate(data, data, data, uniformVolume(22, 1000.0));
         assertThat(snapshot.vol20AnnualizedPct()).isNotNaN();
         assertThat(snapshot.vol20Quantile()).isNotNaN();
+        assertThat(snapshot.vol20Quantile()).isBetween(0.0, 1.0);
+    }
+
+    /**
+     * vol20 백분위는 롤링 변동성 시계열 안에서의 순위라, 관측 기간이 곧 표본 수다.
+     * 60거래일이면 표본 40개(그마저 19일씩 겹쳐 독립 관측은 3개 수준)라 백분위가 거칠다.
+     * 252거래일(1년)이면 232개로 늘어 같은 지표가 훨씬 촘촘해진다.
+     */
+    @Test
+    void 관측기간이_길수록_롤링변동성_표본수가_늘어난다() {
+        assertThat(VolatilityIndicatorCalculator.rollingAnnualizedVol(new double[59])).hasSize(40);
+        assertThat(VolatilityIndicatorCalculator.rollingAnnualizedVol(new double[251])).hasSize(232);
+    }
+
+    @Test
+    void calculate_252거래일_입력도_동일하게_동작한다() {
+        // 관측 기간을 늘려도 다른 지표는 끝에서 20일만 보므로 영향이 없고, vol20Quantile만 정밀해진다.
+        double[] data = ascendingClose(252);
+        VolatilityIndicatorCalculator.IndicatorSnapshot snapshot =
+                VolatilityIndicatorCalculator.calculate(data, data, data, uniformVolume(252, 1000.0));
+
+        assertThat(snapshot.dailyReturnPct()).isNotNaN();
+        assertThat(snapshot.vol20AnnualizedPct()).isNotNaN();
         assertThat(snapshot.vol20Quantile()).isBetween(0.0, 1.0);
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,31 @@
+# 로컬 테스트 전용 프로파일.
+# application.yml 위에 덮어써서, 환경변수 없이도 스프링 컨텍스트가 뜨게 한다.
+# 여기 값은 전부 더미다. 실제 자격증명을 절대 넣지 말 것.
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+
+app:
+  jwt:
+    # Base64로 디코딩했을 때 32바이트 이상이어야 한다(HS256 최소 키 길이).
+    secret: bG9jYWwtdGVzdC1vbmx5LWR1bW15LWp3dC1zZWNyZXQtbm90LWEtcmVhbC1rZXk=
+
+report:
+  callback:
+    secret: test-callback-secret


### PR DESCRIPTION
## 💡 관련 이슈
- Close #40 

## 🛠 작업 내용
- stock: 코스피 200 종목 정보 조회 & volatility: 변동성 탐지 및 리포트 생성 의 자동화를 위해 선행 과제 수행.
- stock 리펙터링. 기존의 로직에서 종목 정보를 업데이트 할 때, 일부가 누락되던 에러 수정.
- StockUseCase 리펙터링. 책임 분리해서 UseCase는 조율만 담당하게 수정.
- 변동성 탐지에서 종료 후 재실행 시, 기존 리포트 url이 삭제되는 문제를 upsert로 변경하여 해결.
- 변동성 탐지에서 종목 정보 패치를 서버 시간에서 실제 거래일로 수정해 시간이 어긋나는 문제 해결.


# 📸 결과 캡쳐화면
- 오류랑 예외 수정하고 리펙터링이 주된 작업이어서 결과 화면은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * KOSPI 200 동기화 결과에 시세 반영 성공 건수와 반영되지 않은 종목 코드가 포함됩니다.
  * 종목 조회 API의 페이지 및 페이지 크기 입력 범위가 검증됩니다.
  * 변동성 탐지·리포트 결과에 거래일이 표시됩니다.
  * 변동성 데이터가 거래일 기준으로 조회·관리됩니다.

* **버그 수정**
  * 거래일이 누락된 시세 응답을 안전하게 처리합니다.
  * 비정상적으로 많은 종목 편출 시 동기화를 중단합니다.
  * 무한대·잘못된 0 나눗셈 값이 변동성 알림에 반영되지 않습니다.

* **테스트**
  * 주식 동기화, 거래일 처리, 변동성 분석 및 입력 검증 테스트를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->